### PR TITLE
[Feat] 히트맵 위젯 (4-b) 로직 및 UI 수정

### DIFF
--- a/presentation/src/main/java/com/hihihihi/gureumpage/ui/bookdetail/components/AddManualHistoryDialog.kt
+++ b/presentation/src/main/java/com/hihihihi/gureumpage/ui/bookdetail/components/AddManualHistoryDialog.kt
@@ -101,9 +101,9 @@ fun AddManualHistoryDialog(
 
 
     val canSave = startTime != null && endTime != null &&
-            (endTime!!.isAfter(startTime) || endTime == startTime) &&
+            endTime!!.isAfter(startTime)  &&
             startPageNum != null && endPageNum != null &&
-            startPageNum > 0 && endPageNum > 0 &&
+            startPageNum >= 0 && endPageNum > 0 &&
             endPageNum >= startPageNum
 
     Dialog(onDismissRequest = onDismiss) {

--- a/presentation/src/main/java/com/hihihihi/gureumpage/widgets/heatmap/DummyData.kt
+++ b/presentation/src/main/java/com/hihihihi/gureumpage/widgets/heatmap/DummyData.kt
@@ -28,8 +28,7 @@ object DummyData {
         }
 
         return HeatPayload(
-            monthLeft = monthLeft,
-            monthRight = monthRight,
+            monthHeaders = listOf(monthLeft,monthRight),
             levels = levels
         )
     }

--- a/presentation/src/main/java/com/hihihihi/gureumpage/widgets/heatmap/HistoryHeatMapWidget.kt
+++ b/presentation/src/main/java/com/hihihihi/gureumpage/widgets/heatmap/HistoryHeatMapWidget.kt
@@ -1,22 +1,18 @@
 package com.hihihihi.gureumpage.widgets.heatmap
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
-import androidx.glance.LocalContext
 import androidx.glance.action.actionParametersOf
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.action.actionRunCallback
-import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
@@ -61,25 +57,21 @@ class HistoryHeatMapWidget : GlanceAppWidget() {
             val state = currentState<Preferences>()
             val json = state[stringPreferencesKey(WIDGET_DATA_KEY)].orEmpty()
             val payload = runCatching { Gson().fromJson(json, HeatPayload::class.java) }
-                .getOrNull() ?: HeatPayload(monthLeft = "", monthRight = "", levels = emptyList())
+                .getOrNull() ?: HeatPayload(monthHeaders = emptyList(), levels = emptyList())
 
             payload.levels.sortedBy { it.ymd }
 
-            Log.d("HistoryHeatMapWidget","payload:$payload")
-
             Column(
                 modifier = GlanceModifier
-                    .fillMaxSize()
-                    .padding(10.dp),
+                    .fillMaxSize(),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalAlignment = Alignment.CenterHorizontally
 
             ) {
-
                 Box(
                     modifier = GlanceModifier
-                        .height(180.dp)
-                        .width(180.dp)
+                        .height(160.dp)
+                        .width(160.dp)
                         .padding(10.dp)
                         .background(
                             ColorProvider(R.color.heat_bg)
@@ -88,137 +80,149 @@ class HistoryHeatMapWidget : GlanceAppWidget() {
                                 parameters = actionParametersOf()
                             )
                         ),
-                    contentAlignment = Alignment.TopStart
+                    contentAlignment = Alignment.Center
                 ) {
+
                     Column(
                         horizontalAlignment = Alignment.Start,
-                        verticalAlignment = Alignment.Top
+                        verticalAlignment = Alignment.Top,
                     ) {
-                        // 헤더(월 표시)
+                        // 월 헤더 (1일이 포함된 열 위에만 표시)
                         Row(
-                            modifier = GlanceModifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically
+                            modifier = GlanceModifier.fillMaxWidth()
                         ) {
-                            Spacer(GlanceModifier.width(16.dp))
-                            Text(
-                                text = payload.monthLeft,
-                                style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Medium,color = ColorProvider(R.color.heat_label)),
+                            Spacer(GlanceModifier.width(12.dp)) // 요일 라벨 공간
 
-                                modifier = GlanceModifier.defaultWeight()
-                            )
-                            Text(
-                                text = payload.monthRight,
-                                style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Medium, color = ColorProvider(R.color.heat_label)),
-
-                                modifier = GlanceModifier.defaultWeight()
-                            )
+                            for (col in 0 until 8) {
+                                val monthHeader = payload.monthHeaders.getOrNull(col) ?: ""
+                                Box(
+                                    modifier = GlanceModifier.width(16.dp)
+                                        .padding(horizontal = 1.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    if (monthHeader.isNotEmpty()) {
+                                        Text(
+                                            text = monthHeader,
+                                            style = TextStyle(
+                                                fontSize = 10.sp,
+                                                fontWeight = FontWeight.Medium,
+                                                color = ColorProvider(R.color.heat_label)
+                                            )
+                                        )
+                                    }
+                                }
+                            }
                         }
 
-                        Spacer(GlanceModifier.height(6.dp))
-                        Column {
-                            // 본문 : 2달 (요일 7행 × 9열)
-                            for (row in 0 until 7) {
-                                Row(
-                                    modifier = GlanceModifier.fillMaxWidth()
-                                        .padding(bottom = if (row < 6) 4.dp else 0.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    // 요일 라벨
+                        Row {
+                            // 요일 라벨을 세로로 표시
+                            Column(
+                                modifier = GlanceModifier.padding(end = 4.dp)
+                            ) {
+                                for (day in Yoil) {
                                     Text(
-                                        text = Yoil[row],
+                                        text = day,
                                         style = TextStyle(
-                                            fontSize = 12.sp,
+                                            fontSize = 8.sp,
                                             fontWeight = FontWeight.Normal,
                                             color = ColorProvider(R.color.heat_label)
                                         ),
-
-                                        modifier = GlanceModifier.width(16.dp)
+                                        modifier = GlanceModifier
+                                            .height(15.dp)
+                                        // .padding(bottom = 1.dp)
                                     )
-                                    // 9주 셀
-                                    for (col in 0 until 9) {
-                                        val idx = row * 9 + col // row-major
-                                        val cell = payload.levels.getOrNull(idx) ?: HeatCell()
-                                        HeatCellBox(cell)
+                                }
+                            }
+
+                            // 본문: 2달 (9주 × 7일) - 세로로 일주일 표시
+                            Row {
+                                for (col in 0 until 8) {
+                                    Column(
+                                        modifier = GlanceModifier
+                                            .padding(end = if (col < 7) 1.dp else 0.dp)
+                                    ) {
+                                        for (row in 0 until 7) {
+                                            val idx = col * 7 + row
+                                            val cell = payload.levels.getOrNull(idx) ?: HeatCell()
+                                            HeatCellBox(cell)
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                 }
-
-
-
             }
         }
     }
-}
 
-@Composable
-private fun HeatCellBox(cell: HeatCell) {
-    val zone = java.time.ZoneId.systemDefault()
-    val today = LocalDate.now(zone)
-    val date = runCatching { LocalDate.parse(cell.ymd) }.getOrNull()
-    val isToday = date == today
+    @Composable
+    private fun HeatCellBox(cell: HeatCell) {
+        val zone = java.time.ZoneId.systemDefault()
+        val today = LocalDate.now(zone)
+        val date = runCatching { LocalDate.parse(cell.ymd) }.getOrNull()
+        val isToday = date == today
 
-    val size = 14.dp
-    val radius = 3.dp
-    val borderWidth = 1.dp // 1dp는 위젯 렌더링에서 잘 안 보일 수 있음
+        val size = 13.dp
+        val radius = 2.dp
+        val borderWidth = 1.dp // 1dp는 위젯 렌더링에서 잘 안 보일 수 있음
 
-    val colorRes = when (cell.level.coerceIn(0, 4)) {
-        0 -> R.color.heat_cell_0
-        1 -> R.color.heat_cell_1
-        2 -> R.color.heat_cell_2
-        3 -> R.color.heat_cell_3
-        else -> R.color.heat_cell_4
-    }
+        val colorRes = when (cell.level.coerceIn(0, 4)) {
+            0 -> R.color.heat_cell_0
+            1 -> R.color.heat_cell_1
+            2 -> R.color.heat_cell_2
+            3 -> R.color.heat_cell_3
+            else -> R.color.heat_cell_4
+        }
 
-    Box(modifier = GlanceModifier.padding(horizontal = 1.dp)) {
-        if (isToday) {
-            Box(
-                modifier = GlanceModifier
-                    .size(size)
-                    .cornerRadius(radius)
-                    .background(ColorProvider(R.color.systemRed)),
-                contentAlignment = Alignment.Center
-            ) {
-                val innerSize = size - (borderWidth * 2)
-                val innerRadius = (radius - borderWidth).coerceAtLeast(0.dp)
+        Box(modifier = GlanceModifier.padding(1.dp)) {
+            if (isToday) {
                 Box(
                     modifier = GlanceModifier
-                        .size(innerSize)
-                        .cornerRadius(innerRadius)
-                        .background(ColorProvider(colorRes)),
+                        .size(size)
+                        .cornerRadius(radius)
+                        .background(ColorProvider(R.color.systemRed)),
                     contentAlignment = Alignment.Center
                 ) {
-                    date?.let {
-                        Text(
-                            text = it.dayOfMonth.toString(),
-                            style = TextStyle(
-                                color = ColorProvider(android.R.color.black),
-                                fontSize = 10.sp,
-                                fontWeight = FontWeight.Normal
-                            )
-                        )
+                    val innerSize = size - (borderWidth * 2)
+                    val innerRadius = (radius - borderWidth).coerceAtLeast(0.dp)
+                    Box(
+                        modifier = GlanceModifier
+                            .size(innerSize)
+                            .cornerRadius(innerRadius)
+                            .background(ColorProvider(colorRes)),
+                        contentAlignment = Alignment.Center
+                    ) {
+//                        date?.let {
+//                            Text(
+//                                text = it.dayOfMonth.toString(),
+//                                style = TextStyle(
+//                                    color = ColorProvider(android.R.color.black),
+//                                    fontSize = 10.sp,
+//                                    fontWeight = FontWeight.Normal
+//                                )
+//                            )
+//                        }
                     }
                 }
-            }
-        } else {
-            Box(
-                modifier = GlanceModifier
-                    .size(size)
-                    .cornerRadius(radius)
-                    .background(ColorProvider(colorRes))
-            ) {
-//                date?.let {
-//                    Text(
-//                        text = it.dayOfMonth.toString(),
-//                        style = TextStyle(
-//                            color = ColorProvider(android.R.color.black),
-//                            fontSize = 10.sp,
-//                            fontWeight = FontWeight.Normal
+            } else {
+                Box(
+                    modifier = GlanceModifier
+                        .size(size)
+                        .cornerRadius(radius)
+                        .background(ColorProvider(colorRes))
+                ) {
+//                    date?.let {
+//                        Text(
+//                            text = it.dayOfMonth.toString(),
+//                            style = TextStyle(
+//                                color = ColorProvider(android.R.color.black),
+//                                fontSize = 8.sp,
+//                                fontWeight = FontWeight.Normal
+//                            )
 //                        )
-//                    )
-//                }
+//                    }
+                }
             }
         }
     }
@@ -226,8 +230,8 @@ private fun HeatCellBox(cell: HeatCell) {
 
 /** 위젯 데이터 구조 */
 data class HeatCell(val ymd: String = "", val level: Int = 0)
+
 data class HeatPayload(
-    val monthLeft: String = "",
-    val monthRight: String = "",
+    val monthHeaders: List<String> = emptyList(),
     val levels: List<HeatCell> = emptyList()
 )

--- a/presentation/src/main/java/com/hihihihi/gureumpage/widgets/heatmap/HistoryHeatMapWorker.kt
+++ b/presentation/src/main/java/com/hihihihi/gureumpage/widgets/heatmap/HistoryHeatMapWorker.kt
@@ -51,11 +51,7 @@ class HistoryHeatMapWorker @AssistedInject constructor(
                 .groupBy { it.date } // it.date: LocalDate
                 .mapValues { (_, items) -> items.sumOf { it.totalReadPageCount } }
 
-            val payload: HeatPayload = if (grouped.isEmpty()) {
-                DummyData.buildDummyPayload()
-            } else {
-                buildPayloadFrom(grouped)
-            }
+            val payload: HeatPayload = buildPayloadFrom(grouped)
 
             val jsonData = Gson().toJson(payload)
 


### PR DESCRIPTION
### ♟️ Issue
- 

## **✨ 주요 변경 사항**
- 기존 로직 1달 전 첫 일요일 부터 -> 오늘 날짜 기준 6주전으로 로직 변경
- UI 가로로 날짜 나타나던 것에서 세로 방향으로 수정

## **✅ 체크리스트**
- [x]  🌱 merge 브랜치 확인
- [x]  🙋 reviewer 설정
- [x]  👨‍🔧 assignees 설정
- [x]  🏷️ label 설정
- [x]  ⚙️ projects 등록
- [ ]  🛠️ development 이슈 등록

## **💬 비고**
- 4-a 같은 로직으로 반응형 구현해보려 했으나.. 현재 Row 가 10줄을 넘어가면 자동으로 컷하는..?? Glance의 특성으로 인해 막혔음 .. ㅠ

## **📸 스크린샷**
> e.g. `<img width="45%" src="링크" />`
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/2018b871-1bd9-4f8a-a23f-4676de3297ab" />
