### PR TITLE
[Refactor] Type-Safe 네비게이션 적용 및 UI 레이어 상태/성능 최적화

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,4 @@
 import java.util.Properties
-import kotlin.apply
 
 plugins {
     alias(libs.plugins.android.application)
@@ -63,40 +62,30 @@ android {
 }
 
 dependencies {
-
     implementation(project(":presentation"))
     implementation(project(":data"))
     implementation(project(":domain"))
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.material3)
-
-    implementation(libs.androidx.navigation.compose)
-
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.android.compiler)
-    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
-
-    // kakao auth
-    implementation("com.kakao.sdk:v2-user:2.20.3")
-
-    // naver auth
-    implementation("com.navercorp.nid:oauth:5.9.0")
-
-    implementation(libs.play.services.oss.licenses)
-
-    implementation(libs.androidx.work.runtime.ktx)
-    implementation("androidx.hilt:hilt-work:1.2.0")
-
-    implementation("com.google.firebase:firebase-auth")
-
-    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.play.services.oss.licenses)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.hilt.work)
+    implementation(libs.kakao.user)
+    implementation(libs.naver.oauth)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.bundles.compose)
+    implementation(libs.bundles.hilt)
+    implementation(libs.androidx.hilt.navigation.compose)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.auth)
+
+    ksp(libs.hilt.android.compiler)
+    ksp(libs.androidx.hilt.compiler)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/hihihihi/gureumpage/MainActivity.kt
+++ b/app/src/main/java/com/hihihihi/gureumpage/MainActivity.kt
@@ -373,7 +373,7 @@ fun GureumPageApp(
     val currentDestination = navBackStackEntry?.destination
 
     val isAuthRoute = currentDestination?.hierarchy?.any {
-        it.hasRoute(Login::class) || it.hasRoute(OnBoarding::class)
+        it.hasRoute(Login::class) || it.hasRoute(OnBoarding::class) || it.hasRoute(Splash::class)
     } == true
     val isBottomNavRoute = currentDestination?.let { dest ->
         BottomNavItem.items.any { item -> dest.hierarchy.any { it.hasRoute(item.routeClass) } }

--- a/app/src/main/java/com/hihihihi/gureumpage/MainActivity.kt
+++ b/app/src/main/java/com/hihihihi/gureumpage/MainActivity.kt
@@ -20,8 +20,17 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.view.WindowCompat
@@ -30,26 +39,41 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.google.firebase.auth.FirebaseAuth
 import com.hihihihi.domain.model.GureumThemeType
+import com.hihihihi.domain.repository.NetworkMonitor
 import com.hihihihi.domain.usecase.user.GetOnboardingCompleteUseCase
 import com.hihihihi.domain.usecase.user.GetThemeFlowUseCase
 import com.hihihihi.domain.usecase.user.UpdateLastVisitUseCase
-import com.hihihihi.domain.repository.NetworkMonitor
+import com.hihihihi.gureumpage.service.FloatingTimerService
 import com.hihihihi.presentation.designsystem.components.GureumAppBar
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
+import com.hihihihi.presentation.navigation.BookDetail
 import com.hihihihi.presentation.navigation.BottomNavItem
 import com.hihihihi.presentation.navigation.GureumBottomNavBar
 import com.hihihihi.presentation.navigation.GureumNavGraph
-import com.hihihihi.presentation.navigation.NavigationRoute
+import com.hihihihi.presentation.navigation.Home
+import com.hihihihi.presentation.navigation.Library
+import com.hihihihi.presentation.navigation.Login
+import com.hihihihi.presentation.navigation.MindMap
+import com.hihihihi.presentation.navigation.MyPage
+import com.hihihihi.presentation.navigation.OnBoarding
+import com.hihihihi.presentation.navigation.Quotes
+import com.hihihihi.presentation.navigation.Splash
+import com.hihihihi.presentation.navigation.StatisticsMonthly
+import com.hihihihi.presentation.navigation.StatisticsWeekly
+import com.hihihihi.presentation.navigation.StatisticsYearly
+import com.hihihihi.presentation.navigation.Timer
+import com.hihihihi.presentation.navigation.Withdraw
 import com.hihihihi.presentation.notification.common.Channels
 import com.hihihihi.presentation.ui.nonetwork.NoNetworkScreen
-import com.hihihihi.gureumpage.service.FloatingTimerService
 import com.hihihihi.presentation.ui.timer.LocalAppBarUpClick
 import com.hihihihi.presentation.ui.timer.TimerRepository
 import dagger.hilt.android.AndroidEntryPoint
@@ -59,8 +83,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.collections.contains
-import kotlin.text.startsWith
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -68,7 +90,7 @@ class MainActivity : ComponentActivity() {
     class GureumThemeViewModel @Inject constructor(
         getTheme: GetThemeFlowUseCase,
         private val networkManager: NetworkMonitor,
-        private val getOnboardingCompleteUseCase: GetOnboardingCompleteUseCase
+        private val getOnboardingCompleteUseCase: GetOnboardingCompleteUseCase,
     ) : ViewModel() {
         val theme = getTheme().stateIn(viewModelScope, SharingStarted.Lazily, GureumThemeType.DARK)
         val isConnected = networkManager.networkState
@@ -95,14 +117,12 @@ class MainActivity : ComponentActivity() {
     private var _navController: NavHostController? = null
     private var pendingDeepLink: Intent? = null
 
-    // 위젯 라우트를 저장할 변수 추가
-    private var _widgetRoute: String? = null
+    private var _widgetRoute: Any? = null
 
     @SuppressLint("ContextCastToActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // onCreate에서 인텐트 처리
         if (isWidgetDeepLink(intent)) {
             _widgetRoute = extractWidgetRoute(intent)
         }
@@ -136,18 +156,18 @@ class MainActivity : ComponentActivity() {
                     val user = FirebaseAuth.getInstance().currentUser
 
                     if (user == null) {
-                        navController.navigate(NavigationRoute.Login.route) {
+                        navController.navigate(Login) {
                             popUpTo(0) { inclusive = true }
                             launchSingleTop = true
                         }
                     } else {
                         if (viewModel.getOnboardingComplete(user.uid).first()) {
-                            navController.navigate(NavigationRoute.Home.route) {
+                            navController.navigate(Home) {
                                 popUpTo(0) { inclusive = true }
                                 launchSingleTop = true
                             }
                         } else {
-                            navController.navigate(NavigationRoute.OnBoarding.route) {
+                            navController.navigate(OnBoarding) {
                                 popUpTo(0) { inclusive = true }
                                 launchSingleTop = true
                             }
@@ -168,14 +188,12 @@ class MainActivity : ComponentActivity() {
             }
 
             LaunchedEffect(Unit) {
-                // onCreate에서 처리한 위젯 라우트가 있다면 사용
                 if (_widgetRoute != null) {
                     return@LaunchedEffect
                 }
 
                 if (routeIfNotificationDeepLink(initIntent)) return@LaunchedEffect
 
-                // 보류분 처리도 동일 정책
                 pendingDeepLink?.let { pending ->
                     if (isWidgetDeepLink(pending)) {
                         _widgetRoute = extractWidgetRoute(pending)
@@ -186,13 +204,12 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
-            // 모드 상태에 따라 GureumPageTheme 에 반영
             GureumPageTheme(darkTheme = isDark) {
                 Surface(modifier = Modifier.fillMaxSize(), color = GureumTheme.colors.background) {
                     if (!isConnected) {
                         NoNetworkScreen(
                             onRefresh = { viewModel.recheckNetwork() },
-                            onExit = { finish() }
+                            onExit = { finish() },
                         )
                     } else {
                         GureumPageApp(
@@ -200,8 +217,8 @@ class MainActivity : ComponentActivity() {
                             initIntent,
                             isTimerRunning,
                             timerRepository,
-                            pendingWidgetRoute = _widgetRoute, // 저장된 위젯 라우트 전달
-                            onWidgetRouteConsumed = { _widgetRoute = null }
+                            pendingWidgetRoute = _widgetRoute,
+                            onWidgetRouteConsumed = { _widgetRoute = null },
                         )
                     }
                 }
@@ -224,10 +241,8 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
 
-        // 위젯 딥링크인 경우 처리
         if (isWidgetDeepLink(intent)) {
             _widgetRoute = extractWidgetRoute(intent)
-            // NavController가 준비되었다면 바로 네비게이션
             _navController?.let { navController ->
                 _widgetRoute?.let { route ->
                     navController.navigate(route) {
@@ -243,108 +258,90 @@ class MainActivity : ComponentActivity() {
         if (_navController != null && _navController!!.graph.nodes.isNotEmpty()) {
             if (routeIfNotificationDeepLink(intent)) return
         } else {
-            // 그래프 준비 전이면 보류
             pendingDeepLink = intent
         }
     }
 
     private fun routeIfNotificationDeepLink(intent: Intent): Boolean {
         val uri = intent.data ?: return false
-        // 위젯 스킴은 제외
         if (uri.scheme == "gureumpage" && uri.host == "app") return false
 
         return routeNotificationUri(uri).also { handled ->
             if (handled) {
-                // 재진입 방지
                 intent.data = null
                 setIntent(intent)
             }
         }
     }
 
-    private fun extractWidgetRoute(intent: Intent): String? {
+    private fun extractWidgetRoute(intent: Intent): Any? {
         val uri = intent.data ?: return null
 
         return when {
             uri.toString().matches(Regex("gureumpage://app/book/missedRecord/[^/?]+.*")) -> {
                 val bookId = uri.pathSegments.lastOrNull()
-                bookId?.let {
-                    NavigationRoute.BookDetail.createRoute(
-                        bookId = it,
-                        showAddManualRecord = true
-                    )
-                }
+                bookId?.let { BookDetail(bookId = it, showAddManualRecord = true) }
             }
 
             uri.toString().matches(Regex("gureumpage://app/book/timer/[^/?]+.*")) -> {
                 val bookId = uri.pathSegments.lastOrNull()
-                bookId?.let { NavigationRoute.Timer.createRoute(userBookId = it) }
+                bookId?.let { Timer(userBookId = it) }
             }
 
             uri.toString().matches(Regex("gureumpage://app/book/addQuote/[^/?]+.*")) -> {
                 val bookId = uri.pathSegments.lastOrNull()
-                bookId?.let {
-                    NavigationRoute.BookDetail.createRoute(
-                        bookId = it,
-                        showAddQuote = true
-                    )
-                }
+                bookId?.let { BookDetail(bookId = it, showAddQuote = true) }
             }
 
             uri.toString().matches(Regex("gureumpage://app/book/[^/?]+.*")) -> {
                 val bookId = uri.pathSegments.lastOrNull()
-                bookId?.let { NavigationRoute.BookDetail.createRoute(bookId = it) }
+                bookId?.let { BookDetail(bookId = it) }
             }
 
-            else -> {
-                null
-            }
+            else -> null
         }
     }
 
     private fun isWidgetDeepLink(intent: Intent): Boolean {
         val uri = intent.data ?: return false
-        val isWidget = uri.scheme == "gureumpage" && uri.host == "app"
-        return isWidget
+        return uri.scheme == "gureumpage" && uri.host == "app"
     }
 
     private fun routeNotificationUri(uri: Uri): Boolean {
         val nc = _navController ?: return false
-        val target = when {
+        val targetRoute: Any = when {
             uri.host == "home" || uri.pathSegments.firstOrNull() == "home" ->
-                NavigationRoute.Home.route
+                Home
 
             uri.host == "bookdetail" || uri.pathSegments.firstOrNull() == "bookdetail" ->
-                uri.lastPathSegment?.let { NavigationRoute.BookDetail.createRoute(it) }
+                uri.lastPathSegment?.let { BookDetail(bookId = it) } ?: return false
 
             uri.host in setOf("statistics", "stats") ||
                     uri.pathSegments.firstOrNull() in setOf("statistics", "stats") ->
                 when (uri.pathSegments.getOrNull(1)) {
-                    "weekly" -> NavigationRoute.StatisticsWeekly.route
-                    "monthly" -> NavigationRoute.StatisticsMonthly.route
-                    "yearly" -> NavigationRoute.StatisticsYearly.route
-                    else -> NavigationRoute.StatisticsWeekly.route
+                    "monthly" -> StatisticsMonthly
+                    "yearly" -> StatisticsYearly
+                    else -> StatisticsWeekly
                 }
 
-            else -> null
-        } ?: return false
+            else -> return false
+        }
 
-        if (target == NavigationRoute.Home.route) {
-            nc.navigate(NavigationRoute.Home.route) {
-                popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+        if (targetRoute is Home) {
+            nc.navigate(Home) {
+                popUpTo<Splash> { inclusive = true }
                 launchSingleTop = true
                 restoreState = true
             }
             return true
         }
 
-        // Home 보이지 않게 쌓고 → Target
-        nc.navigate(NavigationRoute.Home.route) {
-            popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+        nc.navigate(Home) {
+            popUpTo<Splash> { inclusive = true }
             launchSingleTop = true
             restoreState = true
         }
-        nc.navigate(target) {
+        nc.navigate(targetRoute) {
             launchSingleTop = true
             restoreState = true
         }
@@ -364,8 +361,8 @@ fun GureumPageApp(
     initIntent: Intent,
     isTimerRunning: Boolean,
     timerRepository: TimerRepository,
-    pendingWidgetRoute: String? = null,
-    onWidgetRouteConsumed: () -> Unit = {}
+    pendingWidgetRoute: Any? = null,
+    onWidgetRouteConsumed: () -> Unit = {},
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -373,20 +370,26 @@ fun GureumPageApp(
 
     var lastBackMillis by remember { mutableLongStateOf(0L) }
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
+    val currentDestination = navBackStackEntry?.destination
 
-    LaunchedEffect(currentRoute, isTimerRunning) {
-        if (isTimerRunning &&
-            currentRoute != null &&
-            !currentRoute.startsWith(NavigationRoute.Timer.route) &&
-            currentRoute != NavigationRoute.Splash.route &&
-            currentRoute != NavigationRoute.Login.route &&
-            currentRoute != NavigationRoute.OnBoarding.route
-        ) {
+    val isAuthRoute = currentDestination?.hierarchy?.any {
+        it.hasRoute(Login::class) || it.hasRoute(OnBoarding::class)
+    } == true
+    val isBottomNavRoute = currentDestination?.let { dest ->
+        BottomNavItem.items.any { item -> dest.hierarchy.any { it.hasRoute(item.routeClass) } }
+    } ?: false
+    val isHomeRoute = currentDestination?.hasRoute(Home::class) == true
+    val isTimerRoute = currentDestination?.hasRoute(Timer::class) == true
+
+    LaunchedEffect(currentDestination, isTimerRunning) {
+        val isExcludedFromTimer = currentDestination?.hierarchy?.any {
+            it.hasRoute(Timer::class) || it.hasRoute(Splash::class) ||
+                    it.hasRoute(Login::class) || it.hasRoute(OnBoarding::class)
+        } == true
+        if (isTimerRunning && currentDestination != null && !isExcludedFromTimer) {
             val userBookId = timerRepository.getTimerBookId()
-
-            navController.navigate(NavigationRoute.Timer.createRoute(userBookId)) {
-                popUpTo(NavigationRoute.Home.route) {
+            navController.navigate(Timer(userBookId = userBookId)) {
+                popUpTo<Home> {
                     inclusive = false
                     saveState = false
                 }
@@ -394,21 +397,6 @@ fun GureumPageApp(
             }
         }
     }
-
-    val hideBottomBarRoutes = listOf(
-        NavigationRoute.Login.route,
-        NavigationRoute.OnBoarding.route,
-        NavigationRoute.BookDetail.route,
-        NavigationRoute.Timer.route,
-        NavigationRoute.MindMap.route,
-        NavigationRoute.Withdraw.route,
-        NavigationRoute.Search.route,
-        NavigationRoute.Splash.route
-    )
-
-    val bottomRoutes = remember { BottomNavItem.items.map { it.route }.toSet() }
-    val authRoutes =
-        remember { setOf(NavigationRoute.Login.route, NavigationRoute.OnBoarding.route) }
 
     var initialHandle by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(initialHandle) {
@@ -419,25 +407,21 @@ fun GureumPageApp(
 
     var timerAppbarUp by remember { mutableStateOf(0L) }
 
-    LaunchedEffect(currentRoute) {
-        if (currentRoute != NavigationRoute.Timer.route) {
-            timerAppbarUp = 0L
-        }
+    LaunchedEffect(currentDestination) {
+        if (!isTimerRoute) timerAppbarUp = 0L
     }
 
-    BackHandler(enabled = currentRoute !in authRoutes) {
+    BackHandler(enabled = !isAuthRoute) {
         when {
-            // 바텀 내비 아이템 중 홈이 아닐 때 -> 홈으로 스위칭
-            currentRoute in bottomRoutes && currentRoute != NavigationRoute.Home.route -> {
-                navController.navigate(NavigationRoute.Home.route) {
+            isBottomNavRoute && !isHomeRoute -> {
+                navController.navigate(Home) {
                     popUpTo(navController.graph.findStartDestination().id) { saveState = true }
                     launchSingleTop = true
                     restoreState = true
                 }
             }
 
-            // 홈이면 → 종료
-            currentRoute == NavigationRoute.Home.route -> {
+            isHomeRoute -> {
                 val now = System.currentTimeMillis()
                 if (now - lastBackMillis < 2000L) (context as? Activity)?.finish()
                 else {
@@ -446,13 +430,11 @@ fun GureumPageApp(
                 }
             }
 
-            // 그 외 화면
             else -> {
                 val popped = navController.popBackStack()
                 if (!popped) {
-                    // 항상 홈을 거쳐 종료하기
-                    if (currentRoute != NavigationRoute.Home.route) {
-                        navController.navigate(NavigationRoute.Home.route) {
+                    if (!isHomeRoute) {
+                        navController.navigate(Home) {
                             popUpTo(navController.graph.findStartDestination().id) {
                                 saveState = true
                             }
@@ -467,47 +449,62 @@ fun GureumPageApp(
         }
     }
 
+    val showBottomBar = isBottomNavRoute
+
     Scaffold(
         containerColor = GureumTheme.colors.background,
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
-            when (currentRoute) {
-                NavigationRoute.Library.route -> GureumAppBar(title = "서재")
-                NavigationRoute.Quotes.route -> GureumAppBar(title = "필사 목록")
-                NavigationRoute.StatisticsWeekly.route -> GureumAppBar(title = "통계")
-                NavigationRoute.MyPage.route -> GureumAppBar(title = "마이페이지")
-                NavigationRoute.MindMap.route -> GureumAppBar(navController, "마인드맵", true)
-                NavigationRoute.Timer.route -> GureumAppBar(
-                    navController = navController,
-                    title = "독서 스톱워치",
-                    showUpButton = true,
-                    onUpClick = {
-                        timerAppbarUp = System.currentTimeMillis()
-                    }
-                )
+            when {
+                currentDestination?.hasRoute(Library::class) == true ->
+                    GureumAppBar(title = "서재")
 
-                NavigationRoute.BookDetail.route -> GureumAppBar(navController, "", true)
-                NavigationRoute.Withdraw.route -> GureumAppBar(navController, "계정 탈퇴", true)
+                currentDestination?.hasRoute(Quotes::class) == true ->
+                    GureumAppBar(title = "필사 목록")
+
+                currentDestination?.hasRoute(StatisticsWeekly::class) == true ||
+                        currentDestination?.hasRoute(StatisticsMonthly::class) == true ||
+                        currentDestination?.hasRoute(StatisticsYearly::class) == true ->
+                    GureumAppBar(title = "통계")
+
+                currentDestination?.hasRoute(MyPage::class) == true ->
+                    GureumAppBar(title = "마이페이지")
+
+                currentDestination?.hasRoute(MindMap::class) == true ->
+                    GureumAppBar(navController, "마인드맵", true)
+
+                currentDestination?.hasRoute(Timer::class) == true ->
+                    GureumAppBar(
+                        navController = navController,
+                        title = "독서 스톱워치",
+                        showUpButton = true,
+                        onUpClick = { timerAppbarUp = System.currentTimeMillis() },
+                    )
+
+                currentDestination?.hasRoute(BookDetail::class) == true ->
+                    GureumAppBar(navController, "", true)
+
+                currentDestination?.hasRoute(Withdraw::class) == true ->
+                    GureumAppBar(navController, "계정 탈퇴", true)
             }
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         bottomBar = {
-            if (currentRoute != null && BottomNavItem.items.any { currentRoute.startsWith(it.route) })
-                GureumBottomNavBar(navController = navController)
-        }
+            if (showBottomBar) GureumBottomNavBar(navController = navController)
+        },
     ) { innerPadding ->
         Box(
             Modifier
                 .padding(innerPadding)
                 .fillMaxSize()
-                .background(GureumTheme.colors.background)
+                .background(GureumTheme.colors.background),
         ) {
             CompositionLocalProvider(LocalAppBarUpClick provides timerAppbarUp) {
                 GureumNavGraph(
                     navController = navController,
                     modifier = Modifier.fillMaxSize(),
                     snackbarHostState = snackbarHostState,
-                    pendingWidgetRoute = pendingWidgetRoute
+                    pendingWidgetRoute = pendingWidgetRoute,
                 )
             }
         }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         consumerProguardFiles("consumer-rules.pro")
         //local.properties API KEY 사용하기 위함
         buildConfigField("String", "ALADIN_API_KEY", "\"${localProperties["ALADIN_API_KEY"] ?: ""}\"")
-
     }
+
     //local.properties API KEY 사용하기 위함
     buildFeatures {
         buildConfig = true
@@ -52,40 +52,21 @@ dependencies {
     implementation(project(":domain"))
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    implementation(libs.firebase.functions)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.gson)
+
+    implementation(libs.bundles.network)
+    implementation(libs.bundles.coroutines)
+    implementation(libs.bundles.hilt)
+    ksp(libs.hilt.android.compiler)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.bundles.firebase)
+
+    implementation(libs.bundles.social.auth)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
-
-    // Retrofit
-    implementation(libs.retrofit)
-    implementation(libs.converter.gson)
-    implementation(libs.logging.interceptor)
-
-    // Coroutines
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.coroutines.android)
-
-    // Dagger - Hilt
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.android.compiler)
-
-    // Gson
-    implementation(libs.gson)
-
-    implementation(libs.androidx.work.runtime.ktx)
-
-    implementation(platform("com.google.firebase:firebase-bom:34.0.0"))
-    implementation("com.google.firebase:firebase-firestore")
-    implementation("com.google.firebase:firebase-auth")
-    implementation("com.google.android.gms:play-services-auth:21.4.0")
-
-    implementation("com.navercorp.nid:oauth:5.9.0")
-
-    implementation("com.kakao.sdk:v2-user:2.20.3")
-
-    implementation(libs.androidx.datastore.preferences)
 }
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ firebaseFunctions = "22.0.0"
 googleGmsGoogleServices = "4.4.3"
 
 # Network & Serialization
+kotlinxSerialization = "1.7.3"
 retrofit = "3.0.0"
 converterGson = "3.0.0"
 loggingInterceptor = "5.1.0"
@@ -93,6 +94,7 @@ retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = 
 converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "converterGson" }
 logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "loggingInterceptor" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 # Dependency Injection (Hilt)
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltAndroidVersion" }
@@ -193,5 +195,6 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-gms-google-services = { id = "com.google.gms.google-services", version.ref = "googleGmsGoogleServices" }
 google-oss-licenses = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "ossLicensesPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ navigationCompose = "2.9.3"
 calendarCompose = "2.4.0"
 
 # Firebase & Auth
+firebaseBom = "34.0.0"
 firebaseFunctions = "22.0.0"
 googleGmsGoogleServices = "4.4.3"
 
@@ -27,7 +28,17 @@ gson = "2.13.1"
 
 # Dependency Injection (Hilt)
 hiltAndroidVersion = "2.56.2"
+hiltExtensions = "1.2.0"
+hiltNavigationCompose = "1.1.0"
 javaxInject = "1"
+
+# Social Auth
+kakaoSdk = "2.20.3"
+naverOauth = "5.9.0"
+playServicesAuth = "21.4.0"
+
+# Image Loading
+coil = "3.3.0"
 
 # UI & Utilities
 datastore = "1.1.1"
@@ -35,9 +46,12 @@ dynamicanimation = "1.1.0"
 gysoTreeview = "1.0.1"
 glance = "1.1.1"
 workVersion = "2.10.3"
+mpAndroidChart = "3.1.0"
+lottie = "5.2.0"
+composeRatingbar = "1.3.12"
+coreSplashscreen = "1.0.1"
 
 # Google Play & Open Source
-playReview = "2.0.2"
 ossLicensesPlugin = "0.10.6"
 playServicesOssLicenses = "17.2.1"
 
@@ -68,7 +82,10 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 androidx-ui-viewbinding = { group = "androidx.compose.ui", name = "ui-viewbinding" }
 calendar-compose = { group = "com.kizitonwose.calendar", name = "compose", version.ref = "calendarCompose" }
 
-# Firebase
+# Firebase (BOM 관리 → firestore·auth는 버전 생략)
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
+firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 firebase-functions = { group = "com.google.firebase", name = "firebase-functions", version.ref = "firebaseFunctions" }
 
 # Network & Serialization
@@ -81,6 +98,18 @@ gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltAndroidVersion" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hiltAndroidVersion" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javaxInject" }
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltExtensions" }
+androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltExtensions" }
+
+# Social Auth
+kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoSdk" }
+naver-oauth = { group = "com.navercorp.nid", name = "oauth", version.ref = "naverOauth" }
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
+
+# Image Loading (Coil)
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 
 # UI & Utilities
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
@@ -89,10 +118,13 @@ gyso-treeview = { group = "io.github.guaishoun", name = "gyso-treeview", version
 androidx-glance = { group = "androidx.glance", name = "glance", version.ref = "glance" }
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workVersion" }
+mp-android-chart = { group = "com.github.PhilJay", name = "MPAndroidChart", version.ref = "mpAndroidChart" }
+lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie" }
+compose-ratingbar = { group = "com.github.a914-gowtham", name = "compose-ratingbar", version.ref = "composeRatingbar" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 
 # Google Play & Open Source
-google-play-review = { group = "com.google.android.play", name = "review", version.ref = "playReview" }
-google-play-review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "playReview" }
 play-services-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
 
 # Test
@@ -112,6 +144,10 @@ compose = [
     "androidx-navigation-compose",
     "androidx-ui-viewbinding"
 ]
+lifecycle = [
+    "androidx-lifecycle-runtime-ktx",
+    "androidx-lifecycle-runtime-compose"
+]
 coroutines = [
     "kotlinx-coroutines-core",
     "kotlinx-coroutines-android"
@@ -125,6 +161,27 @@ network = [
 hilt = [
     "hilt-android",
     "javax-inject"
+]
+firebase = [
+    "firebase-firestore",
+    "firebase-auth",
+    "firebase-functions"
+]
+social-auth = [
+    "kakao-user",
+    "naver-oauth",
+    "play-services-auth"
+]
+coil = [
+    "coil-compose",
+    "coil-network-okhttp"
+]
+compose-extra = [
+    "calendar-compose",
+    "mp-android-chart",
+    "lottie-compose",
+    "compose-ratingbar",
+    "androidx-compose-material-icons-extended"
 ]
 glance = [
     "androidx-glance",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ espressoCore = "3.7.0"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,12 +1,3 @@
-import java.util.Properties
-
-val localProperties = Properties().apply {
-    val localFile = rootProject.file("local.properties")
-    if (localFile.exists()) {
-        load(localFile.inputStream())
-    }
-}
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -21,10 +12,7 @@ android {
 
     defaultConfig {
         minSdk = 26
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-
-
     }
 
     buildTypes {
@@ -58,15 +46,30 @@ dependencies {
     implementation(project(":domain"))
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.lifecycle.runtime.compose)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.hilt.work)
+    implementation(libs.play.services.oss.licenses)
+
+    // MindMap
+    implementation(libs.gyso.treeview)
+    implementation(libs.androidx.dynamicanimation)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.bundles.compose)
+    implementation(libs.bundles.lifecycle)
+    implementation(libs.bundles.coroutines)
+    implementation(libs.bundles.hilt)
+    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.bundles.glance)
+    implementation(libs.bundles.coil)
+    implementation(libs.bundles.social.auth)
+    implementation(libs.bundles.compose.extra)
+
+    ksp(libs.hilt.android.compiler)
+    ksp(libs.androidx.hilt.compiler)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -74,57 +77,4 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
-
-    implementation(libs.androidx.navigation.compose)
-
-    // Retrofit + Gson
-    implementation(libs.retrofit)
-    implementation(libs.converter.gson)
-
-    // Coroutines + Flow
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.coroutines.android)
-
-    // Hilt (의존성 주입)
-    implementation(libs.hilt.android)
-    implementation("androidx.hilt:hilt-work:1.2.0")
-    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
-    ksp(libs.hilt.android.compiler)
-    ksp("androidx.hilt:hilt-compiler:1.2.0")
-
-    // MindMap
-    implementation(libs.gyso.treeview)
-    implementation(libs.androidx.dynamicanimation)
-    implementation(libs.androidx.ui.viewbinding)
-
-    // Coil
-    implementation("io.coil-kt.coil3:coil-compose:3.3.0")
-    implementation("io.coil-kt.coil3:coil-network-okhttp:3.3.0")
-
-
-    implementation(libs.androidx.datastore.preferences)
-
-    // UI 관련 라이브러리
-    implementation(libs.calendar.compose)
-    implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
-    implementation("com.airbnb.android:lottie-compose:5.2.0")
-    implementation("com.github.a914-gowtham:compose-ratingbar:1.3.12")
-    implementation("androidx.compose.material:material-icons-extended")
-
-    implementation(libs.google.play.review)
-    implementation(libs.google.play.review.ktx)
-    implementation(libs.play.services.oss.licenses)
-
-    implementation(libs.androidx.glance)
-    implementation(libs.androidx.glance.appwidget)
-
-    implementation(libs.androidx.work.runtime.ktx)
-//    implementation("androidx.work:work-runtime-ktx:2.9.0")
-
-    implementation("androidx.core:core-splashscreen:1.0.1")
-
-    // 소셜 로그인 Auth SDK
-    implementation("com.google.android.gms:play-services-auth:21.4.0")
-    implementation("com.kakao.sdk:v2-user:2.20.3")
-    implementation("com.navercorp.nid:oauth:5.9.0")
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -66,6 +67,7 @@ dependencies {
     implementation(libs.bundles.coil)
     implementation(libs.bundles.social.auth)
     implementation(libs.bundles.compose.extra)
+    implementation(libs.kotlinx.serialization.json)
 
     ksp(libs.hilt.android.compiler)
     ksp(libs.androidx.hilt.compiler)

--- a/presentation/src/main/java/com/hihihihi/presentation/navigation/GureumBottomNavigationBar.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/navigation/GureumBottomNavigationBar.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -19,61 +21,70 @@ import androidx.navigation.compose.rememberNavController
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
+import kotlin.reflect.KClass
 
 sealed class BottomNavItem(
-    val route: String,
+    val destination: Any,
+    val routeClass: KClass<*>,
     val label: String,
     val unSelectedIconResId: Int,
-    val onSelectedIconResId: Int
+    val onSelectedIconResId: Int,
 ) {
-    object Home : BottomNavItem(
-        NavigationRoute.Home.route,
-        "홈",
-        R.drawable.ic_home_outline,
-        R.drawable.ic_home_filled
+    object HomeItem : BottomNavItem(
+        destination = Home,
+        routeClass = Home::class,
+        label = "홈",
+        unSelectedIconResId = R.drawable.ic_home_outline,
+        onSelectedIconResId = R.drawable.ic_home_filled,
     )
 
-    object Library : BottomNavItem(
-        NavigationRoute.Library.route,
-        "내 서재",
-        R.drawable.ic_book_outline,
-        R.drawable.ic_book_filled
+    object LibraryItem : BottomNavItem(
+        destination = Library,
+        routeClass = Library::class,
+        label = "내 서재",
+        unSelectedIconResId = R.drawable.ic_book_outline,
+        onSelectedIconResId = R.drawable.ic_book_filled,
     )
 
-    object Quotes : BottomNavItem(
-        NavigationRoute.Quotes.route,
-        "필사",
-        R.drawable.ic_lightbulb_outline,
-        R.drawable.ic_lightbulb_filled
+    object QuotesItem : BottomNavItem(
+        destination = Quotes,
+        routeClass = Quotes::class,
+        label = "필사",
+        unSelectedIconResId = R.drawable.ic_lightbulb_outline,
+        onSelectedIconResId = R.drawable.ic_lightbulb_filled,
     )
 
-    object Statistics : BottomNavItem(
-        NavigationRoute.StatisticsWeekly.route,
-        "통계",
-        R.drawable.ic_chart_pie_outline,
-        R.drawable.ic_chart_pie_filled
+    object StatisticsItem : BottomNavItem(
+        destination = StatisticsWeekly,
+        routeClass = StatisticsWeekly::class,
+        label = "통계",
+        unSelectedIconResId = R.drawable.ic_chart_pie_outline,
+        onSelectedIconResId = R.drawable.ic_chart_pie_filled,
     )
 
-    object MyPage : BottomNavItem(
-        NavigationRoute.MyPage.route,
-        "마이페이지",
-        R.drawable.ic_user_outline,
-        R.drawable.ic_user_filled
+    object MyPageItem : BottomNavItem(
+        destination = MyPage,
+        routeClass = MyPage::class,
+        label = "마이페이지",
+        unSelectedIconResId = R.drawable.ic_user_outline,
+        onSelectedIconResId = R.drawable.ic_user_filled,
     )
 
     companion object {
-        val items = listOf(Library, Quotes, Home, Statistics, MyPage)
+        val items = listOf(LibraryItem, QuotesItem, HomeItem, StatisticsItem, MyPageItem)
     }
 }
 
 @Composable
 fun GureumBottomNavBar(navController: NavHostController) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
+    val currentDestination = navBackStackEntry?.destination
 
     NavigationBar {
         BottomNavItem.items.forEach { item ->
-            val isSelected = currentRoute == item.route
+            val isSelected = currentDestination?.hierarchy?.any {
+                it.hasRoute(item.routeClass)
+            } == true
             val iconId = if (isSelected) item.onSelectedIconResId else item.unSelectedIconResId
 
             NavigationBarItem(
@@ -86,16 +97,12 @@ fun GureumBottomNavBar(navController: NavHostController) {
                 selected = isSelected,
                 label = { Text(item.label, style = MaterialTheme.typography.labelSmall) },
                 onClick = {
+                    if (isSelected) return@NavigationBarItem
 
-                    if (currentRoute == item.route) return@NavigationBarItem
-
-                    if (item.route == NavigationRoute.Home.route) {
-                        val popped = navController.popBackStack(
-                            NavigationRoute.Home.route,
-                            inclusive = false
-                        )
+                    if (item is BottomNavItem.HomeItem) {
+                        val popped = navController.popBackStack<Home>(inclusive = false)
                         if (!popped) {
-                            navController.navigate(NavigationRoute.Home.route) {
+                            navController.navigate(Home) {
                                 popUpTo(navController.graph.findStartDestination().id) {
                                     saveState = true
                                 }
@@ -104,8 +111,8 @@ fun GureumBottomNavBar(navController: NavHostController) {
                             }
                         }
                     } else {
-                        navController.navigate(item.route) {
-                            popUpTo(NavigationRoute.Home.route) {
+                        navController.navigate(item.destination) {
+                            popUpTo<Home> {
                                 saveState = true
                                 inclusive = false
                             }

--- a/presentation/src/main/java/com/hihihihi/presentation/navigation/GureumNavGraph.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/navigation/GureumNavGraph.kt
@@ -4,11 +4,11 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
+import androidx.navigation.toRoute
+import com.hihihihi.domain.model.DateRangePreset
 import com.hihihihi.presentation.ui.bookdetail.BookDetailScreen
 import com.hihihihi.presentation.ui.home.HomeScreen
 import com.hihihihi.presentation.ui.library.LibraryScreen
@@ -27,165 +27,149 @@ import com.hihihihi.presentation.ui.withdraw.WithdrawScreen
 fun GureumNavGraph(
     navController: NavHostController,
     modifier: Modifier = Modifier,
-    startDestination: String = NavigationRoute.Splash.route,
     snackbarHostState: SnackbarHostState,
-    pendingWidgetRoute: String? = null
+    pendingWidgetRoute: Any? = null,
 ) {
     NavHost(
         navController = navController,
-        startDestination = startDestination,
-        modifier = modifier
+        startDestination = Splash,
+        modifier = modifier,
     ) {
-        composable(NavigationRoute.Splash.route) {
+        composable<Splash> {
             SplashView(
                 onNavigateToLogin = {
-                    navController.navigate(NavigationRoute.Login.route) {
-                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+                    navController.navigate(Login) {
+                        popUpTo<Splash> { inclusive = true }
                         launchSingleTop = true
                     }
                 },
                 onNavigateToOnBoarding = {
-                    navController.navigate(NavigationRoute.OnBoarding.route) {
-                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+                    navController.navigate(OnBoarding) {
+                        popUpTo<Splash> { inclusive = true }
                         launchSingleTop = true
                     }
                 },
                 onNavigateToHome = {
-                    navController.navigate(NavigationRoute.Home.route) {
-                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+                    navController.navigate(Home) {
+                        popUpTo<Splash> { inclusive = true }
                         launchSingleTop = true
                     }
                 },
-                onNavigateToWidget = { route ->
+                onNavigateToWidget = { route: Any ->
                     navController.navigate(route) {
-                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+                        popUpTo<Splash> { inclusive = true }
                         launchSingleTop = true
                     }
                 },
-                pendingWidgetRoute = pendingWidgetRoute
+                pendingWidgetRoute = pendingWidgetRoute,
             )
         }
 
-        composable(
-            route = NavigationRoute.Home.route,
+        composable<Home>(
             deepLinks = listOf(
                 navDeepLink { uriPattern = "gureum://home" },
-                navDeepLink { uriPattern = "app://home" }
-            )
+                navDeepLink { uriPattern = "app://home" },
+            ),
         ) {
             HomeScreen(
                 onNavigateToBookDetail = { bookId ->
-                    navController.navigate(NavigationRoute.BookDetail.createRoute(bookId))
+                    navController.navigate(BookDetail(bookId = bookId))
                 },
                 onNavigateToSearch = {
-                    navController.navigate(NavigationRoute.Search.route)
-                }
+                    navController.navigate(Search)
+                },
             )
         }
 
-        composable(NavigationRoute.Login.route) {
+        composable<Login> {
             LoginScreen(
                 onNavigateToHome = {
-                    navController.navigate(NavigationRoute.Home.route) {
-                        popUpTo(NavigationRoute.Login.route) { inclusive = true }
+                    navController.navigate(Home) {
+                        popUpTo<Login> { inclusive = true }
                         launchSingleTop = true
                     }
                 },
                 onNavigateToOnBoarding = {
-                    navController.navigate(NavigationRoute.OnBoarding.route) {
-                        popUpTo(NavigationRoute.Login.route) { inclusive = true }
-                        launchSingleTop = true
-                    }
-                }
-            )
-        }
-
-        composable(NavigationRoute.OnBoarding.route) {
-            OnBoardingScreen(
-                onNavigateToHome = {
-                    navController.navigate(NavigationRoute.Home.route) {
-                        popUpTo(NavigationRoute.OnBoarding.route) { inclusive = true }
+                    navController.navigate(OnBoarding) {
+                        popUpTo<Login> { inclusive = true }
                         launchSingleTop = true
                     }
                 },
-                onNavigateBack = { navController.popBackStack() }
             )
         }
 
-        composable(
-            route = NavigationRoute.MindMap.route,
-            arguments = listOf(
-                navArgument("mindmapId") { type = NavType.StringType },
-                navArgument("bookId") { type = NavType.StringType }
+        composable<OnBoarding> {
+            OnBoardingScreen(
+                onNavigateToHome = {
+                    navController.navigate(Home) {
+                        popUpTo<OnBoarding> { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateBack = { navController.popBackStack() },
             )
-        ) { backStackEntry ->
-            val mindmapId = backStackEntry.arguments?.getString("mindmapId")
-            mindmapId?.let { MindMapScreen(mindmapId = it) }
         }
 
-        composable(NavigationRoute.Quotes.route) { QuotesScreen() }
+        composable<MindMap> { backStackEntry ->
+            val route = backStackEntry.toRoute<MindMap>()
+            MindMapScreen(mindmapId = route.mindmapId ?: "")
+        }
 
-        composable(NavigationRoute.Library.route) {
+        composable<Quotes> { QuotesScreen() }
+
+        composable<Library> {
             LibraryScreen(
                 onNavigateToBookDetail = { bookId ->
-                    navController.navigate(NavigationRoute.BookDetail.createRoute(bookId))
-                }
+                    navController.navigate(BookDetail(bookId = bookId))
+                },
             )
         }
 
-        composable(NavigationRoute.Search.route) {
+        composable<Search> {
             SearchScreen(
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
             )
         }
 
-        composable(
-            route = NavigationRoute.StatisticsWeekly.route,
+        composable<StatisticsWeekly>(
             deepLinks = listOf(
                 navDeepLink { uriPattern = "gureum://statistics/weekly" },
-                navDeepLink { uriPattern = "app://statistics/weekly" }
-            )
-        ) { StatisticsScreen(initialPreset = com.hihihihi.domain.model.DateRangePreset.WEEK) }
+                navDeepLink { uriPattern = "app://statistics/weekly" },
+            ),
+        ) { StatisticsScreen(initialPreset = DateRangePreset.WEEK) }
 
-        composable(
-            route = NavigationRoute.StatisticsMonthly.route,
+        composable<StatisticsMonthly>(
             deepLinks = listOf(
                 navDeepLink { uriPattern = "gureum://statistics/monthly" },
-                navDeepLink { uriPattern = "app://statistics/monthly" }
-            )
-        ) { StatisticsScreen(initialPreset = com.hihihihi.domain.model.DateRangePreset.MONTH) }
+                navDeepLink { uriPattern = "app://statistics/monthly" },
+            ),
+        ) { StatisticsScreen(initialPreset = DateRangePreset.MONTH) }
 
-        composable(
-            route = NavigationRoute.StatisticsYearly.route,
+        composable<StatisticsYearly>(
             deepLinks = listOf(
                 navDeepLink { uriPattern = "gureum://statistics/yearly" },
-                navDeepLink { uriPattern = "app://statistics/yearly" }
-            )
-        ) { StatisticsScreen(initialPreset = com.hihihihi.domain.model.DateRangePreset.YEAR) }
+                navDeepLink { uriPattern = "app://statistics/yearly" },
+            ),
+        ) { StatisticsScreen(initialPreset = DateRangePreset.YEAR) }
 
-        composable(
-            route = NavigationRoute.Timer.route,
-            arguments = listOf(navArgument("userBookId") { type = NavType.StringType })
-        ) { backStackEntry ->
-            val userBookId = requireNotNull(backStackEntry.arguments?.getString("userBookId")) {
-                "TimerScreen requires non-null userBookId"
-            }
+        composable<Timer> { backStackEntry ->
+            val route = backStackEntry.toRoute<Timer>()
             TimerScreen(
-                userBookId = userBookId,
+                userBookId = route.userBookId,
                 onExit = {
                     navController.popBackStack()
-                    navController.navigate(NavigationRoute.BookDetail.createRoute(userBookId)) {
+                    navController.navigate(BookDetail(bookId = route.userBookId)) {
                         launchSingleTop = true
                         restoreState = true
                     }
-                }
+                },
             )
         }
 
-        composable(NavigationRoute.MyPage.route) {
+        composable<MyPage> {
             MyPageScreen(
                 onNavigateToLogin = {
-                    navController.navigate(NavigationRoute.Login.route) {
+                    navController.navigate(Login) {
                         popUpTo(navController.graph.id) {
                             inclusive = true
                             saveState = false
@@ -195,26 +179,12 @@ fun GureumNavGraph(
                     }
                 },
                 onNavigateToWithdraw = { userName ->
-                    navController.navigate(NavigationRoute.Withdraw.createRoute(userName))
-                }
+                    navController.navigate(Withdraw(userName = userName))
+                },
             )
         }
 
-        composable(
-            route = NavigationRoute.BookDetail.route,
-            arguments = listOf(
-                navArgument("bookId") { type = NavType.StringType },
-                navArgument("showAddQuote") {
-                    type = NavType.StringType
-                    nullable = true
-                    defaultValue = "false"
-                },
-                navArgument("showAddManualRecord") {
-                    type = NavType.StringType
-                    nullable = true
-                    defaultValue = "false"
-                }
-            ),
+        composable<BookDetail>(
             deepLinks = listOf(
                 navDeepLink { uriPattern = "gureum://bookdetail/{bookId}" },
                 navDeepLink { uriPattern = "app://bookdetail/{bookId}" },
@@ -225,50 +195,36 @@ fun GureumNavGraph(
                 navDeepLink {
                     uriPattern =
                         "app://bookdetail/{bookId}?showAddQuote={showAddQuote}&showAddManualRecord={showAddManualRecord}"
-                }
-            )
+                },
+            ),
         ) { backStackEntry ->
-            val bookId = backStackEntry.arguments?.getString("bookId")
-            val showAddQuote =
-                backStackEntry.arguments?.getString("showAddQuote")?.toBooleanStrictOrNull()
-                    ?: false
-            val showAddManualRecord =
-                backStackEntry.arguments?.getString("showAddManualRecord")?.toBooleanStrictOrNull()
-                    ?: false
-
-            bookId?.let {
-                BookDetailScreen(
-                    bookId = it,
-                    snackbarHostState = snackbarHostState,
-                    onNavigateToMindmap = { bookId, mindmapId ->
-                        navController.navigate(NavigationRoute.MindMap.createRoute(bookId, mindmapId))
-                    },
-                    onNavigateToTimer = { userBookId ->
-                        navController.navigate(NavigationRoute.Timer.createRoute(userBookId))
-                    },
-                    onNavigateBack = { navController.popBackStack() },
-                    initialShowAddQuote = showAddQuote,
-                    initialShowAddManualRecord = showAddManualRecord
-                )
-            }
+            val route = backStackEntry.toRoute<BookDetail>()
+            BookDetailScreen(
+                bookId = route.bookId,
+                snackbarHostState = snackbarHostState,
+                onNavigateToMindmap = { bookId, mindmapId ->
+                    navController.navigate(MindMap(bookId = bookId, mindmapId = mindmapId))
+                },
+                onNavigateToTimer = { userBookId ->
+                    navController.navigate(Timer(userBookId = userBookId))
+                },
+                onNavigateBack = { navController.popBackStack() },
+                initialShowAddQuote = route.showAddQuote,
+                initialShowAddManualRecord = route.showAddManualRecord,
+            )
         }
 
-        composable(
-            route = NavigationRoute.Withdraw.route,
-            arguments = listOf(navArgument("userName") { type = NavType.StringType })
-        ) { backStackEntry ->
-            val userName = backStackEntry.arguments?.getString("userName")
-            userName?.let {
-                WithdrawScreen(
-                    userName = it,
-                    onNavigateToLogin = {
-                        navController.navigate(NavigationRoute.Login.route) {
-                            popUpTo(0) { inclusive = true }
-                        }
-                    },
-                    onNavigateBack = { navController.popBackStack() }
-                )
-            }
+        composable<Withdraw> { backStackEntry ->
+            val route = backStackEntry.toRoute<Withdraw>()
+            WithdrawScreen(
+                userName = route.userName,
+                onNavigateToLogin = {
+                    navController.navigate(Login) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                },
+                onNavigateBack = { navController.popBackStack() },
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/navigation/GureumNavGraph.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/navigation/GureumNavGraph.kt
@@ -38,19 +38,80 @@ fun GureumNavGraph(
     ) {
         composable(NavigationRoute.Splash.route) {
             SplashView(
-                navController = navController,
+                onNavigateToLogin = {
+                    navController.navigate(NavigationRoute.Login.route) {
+                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToOnBoarding = {
+                    navController.navigate(NavigationRoute.OnBoarding.route) {
+                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToHome = {
+                    navController.navigate(NavigationRoute.Home.route) {
+                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToWidget = { route ->
+                    navController.navigate(route) {
+                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
                 pendingWidgetRoute = pendingWidgetRoute
             )
         }
+
         composable(
             route = NavigationRoute.Home.route,
             deepLinks = listOf(
                 navDeepLink { uriPattern = "gureum://home" },
                 navDeepLink { uriPattern = "app://home" }
             )
-        ) { HomeScreen(navController = navController) }
-        composable(NavigationRoute.Login.route) { LoginScreen(navController) }
-        composable(NavigationRoute.OnBoarding.route) { OnBoardingScreen(navController) }
+        ) {
+            HomeScreen(
+                onNavigateToBookDetail = { bookId ->
+                    navController.navigate(NavigationRoute.BookDetail.createRoute(bookId))
+                },
+                onNavigateToSearch = {
+                    navController.navigate(NavigationRoute.Search.route)
+                }
+            )
+        }
+
+        composable(NavigationRoute.Login.route) {
+            LoginScreen(
+                onNavigateToHome = {
+                    navController.navigate(NavigationRoute.Home.route) {
+                        popUpTo(NavigationRoute.Login.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToOnBoarding = {
+                    navController.navigate(NavigationRoute.OnBoarding.route) {
+                        popUpTo(NavigationRoute.Login.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+
+        composable(NavigationRoute.OnBoarding.route) {
+            OnBoardingScreen(
+                onNavigateToHome = {
+                    navController.navigate(NavigationRoute.Home.route) {
+                        popUpTo(NavigationRoute.OnBoarding.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
+
         composable(
             route = NavigationRoute.MindMap.route,
             arguments = listOf(
@@ -61,9 +122,23 @@ fun GureumNavGraph(
             val mindmapId = backStackEntry.arguments?.getString("mindmapId")
             mindmapId?.let { MindMapScreen(mindmapId = it) }
         }
+
         composable(NavigationRoute.Quotes.route) { QuotesScreen() }
-        composable(NavigationRoute.Library.route) { LibraryScreen(navController) }
-        composable(NavigationRoute.Search.route) { SearchScreen(navController) }
+
+        composable(NavigationRoute.Library.route) {
+            LibraryScreen(
+                onNavigateToBookDetail = { bookId ->
+                    navController.navigate(NavigationRoute.BookDetail.createRoute(bookId))
+                }
+            )
+        }
+
+        composable(NavigationRoute.Search.route) {
+            SearchScreen(
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
+
         composable(
             route = NavigationRoute.StatisticsWeekly.route,
             deepLinks = listOf(
@@ -71,6 +146,7 @@ fun GureumNavGraph(
                 navDeepLink { uriPattern = "app://statistics/weekly" }
             )
         ) { StatisticsScreen(initialPreset = com.hihihihi.domain.model.DateRangePreset.WEEK) }
+
         composable(
             route = NavigationRoute.StatisticsMonthly.route,
             deepLinks = listOf(
@@ -78,6 +154,7 @@ fun GureumNavGraph(
                 navDeepLink { uriPattern = "app://statistics/monthly" }
             )
         ) { StatisticsScreen(initialPreset = com.hihihihi.domain.model.DateRangePreset.MONTH) }
+
         composable(
             route = NavigationRoute.StatisticsYearly.route,
             deepLinks = listOf(
@@ -85,6 +162,7 @@ fun GureumNavGraph(
                 navDeepLink { uriPattern = "app://statistics/yearly" }
             )
         ) { StatisticsScreen(initialPreset = com.hihihihi.domain.model.DateRangePreset.YEAR) }
+
         composable(
             route = NavigationRoute.Timer.route,
             arguments = listOf(navArgument("userBookId") { type = NavType.StringType })
@@ -96,7 +174,6 @@ fun GureumNavGraph(
                 userBookId = userBookId,
                 onExit = {
                     navController.popBackStack()
-
                     navController.navigate(NavigationRoute.BookDetail.createRoute(userBookId)) {
                         launchSingleTop = true
                         restoreState = true
@@ -104,7 +181,25 @@ fun GureumNavGraph(
                 }
             )
         }
-        composable(NavigationRoute.MyPage.route) { MyPageScreen(navController = navController) }
+
+        composable(NavigationRoute.MyPage.route) {
+            MyPageScreen(
+                onNavigateToLogin = {
+                    navController.navigate(NavigationRoute.Login.route) {
+                        popUpTo(navController.graph.id) {
+                            inclusive = true
+                            saveState = false
+                        }
+                        launchSingleTop = true
+                        restoreState = false
+                    }
+                },
+                onNavigateToWithdraw = { userName ->
+                    navController.navigate(NavigationRoute.Withdraw.createRoute(userName))
+                }
+            )
+        }
+
         composable(
             route = NavigationRoute.BookDetail.route,
             arguments = listOf(
@@ -144,8 +239,14 @@ fun GureumNavGraph(
             bookId?.let {
                 BookDetailScreen(
                     bookId = it,
-                    navController = navController,
                     snackbarHostState = snackbarHostState,
+                    onNavigateToMindmap = { bookId, mindmapId ->
+                        navController.navigate(NavigationRoute.MindMap.createRoute(bookId, mindmapId))
+                    },
+                    onNavigateToTimer = { userBookId ->
+                        navController.navigate(NavigationRoute.Timer.createRoute(userBookId))
+                    },
+                    onNavigateBack = { navController.popBackStack() },
                     initialShowAddQuote = showAddQuote,
                     initialShowAddManualRecord = showAddManualRecord
                 )
@@ -158,7 +259,15 @@ fun GureumNavGraph(
         ) { backStackEntry ->
             val userName = backStackEntry.arguments?.getString("userName")
             userName?.let {
-                WithdrawScreen(userName = it, navController = navController)
+                WithdrawScreen(
+                    userName = it,
+                    onNavigateToLogin = {
+                        navController.navigate(NavigationRoute.Login.route) {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    },
+                    onNavigateBack = { navController.popBackStack() }
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/navigation/NavigationRoute.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/navigation/NavigationRoute.kt
@@ -1,37 +1,23 @@
 package com.hihihihi.presentation.navigation
 
-sealed class NavigationRoute(val route: String) {
-    object Splash : NavigationRoute("splash")
-    object Home : NavigationRoute("home")
-    object Login : NavigationRoute("login")
-    object OnBoarding : NavigationRoute("onboarding")
-    object MindMap : NavigationRoute("mindmap/{bookId}/{mindmapId}") {
-        fun createRoute(bookId: String, mindmapId: String?): String = "mindmap/$bookId/$mindmapId"
-    }
+import kotlinx.serialization.Serializable
 
-    object Quotes : NavigationRoute("quotes")
-    object Library : NavigationRoute("library")
-    object Search : NavigationRoute("search")
-    object StatisticsWeekly : NavigationRoute("statistics/weekly")
-    object StatisticsMonthly : NavigationRoute("statistics/monthly")
-    object StatisticsYearly : NavigationRoute("statistics/yearly")
-    object Timer : NavigationRoute("timer/{userBookId}") {
-        fun createRoute(userBookId: String): String = "timer/$userBookId"
-    }
-
-    object MyPage : NavigationRoute("mypage")
-    object BookDetail : NavigationRoute("bookdetail/{bookId}?showAddQuote={showAddQuote}&showAddManualRecord={showAddManualRecord}") {
-        fun createRoute(
-            bookId: String,
-            showAddQuote: Boolean = false,
-            showAddManualRecord: Boolean = false
-        ): String {
-            val route = "bookdetail/$bookId?showAddQuote=$showAddQuote&showAddManualRecord=$showAddManualRecord"
-            return route
-        }
-    }
-
-    object Withdraw : NavigationRoute("withdraw/{userName}") {
-        fun createRoute(userName: String): String = "withdraw/$userName"
-    }
-}
+@Serializable data object Splash
+@Serializable data object Home
+@Serializable data object Login
+@Serializable data object OnBoarding
+@Serializable data object Quotes
+@Serializable data object Library
+@Serializable data object Search
+@Serializable data object MyPage
+@Serializable data object StatisticsWeekly
+@Serializable data object StatisticsMonthly
+@Serializable data object StatisticsYearly
+@Serializable data class MindMap(val bookId: String, val mindmapId: String?)
+@Serializable data class Timer(val userBookId: String)
+@Serializable data class BookDetail(
+    val bookId: String,
+    val showAddQuote: Boolean = false,
+    val showAddManualRecord: Boolean = false
+)
+@Serializable data class Withdraw(val userName: String)

--- a/presentation/src/main/java/com/hihihihi/presentation/navigation/NavigationRoute.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/navigation/NavigationRoute.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 @Serializable data object StatisticsWeekly
 @Serializable data object StatisticsMonthly
 @Serializable data object StatisticsYearly
-@Serializable data class MindMap(val bookId: String, val mindmapId: String?)
+@Serializable data class MindMap(val bookId: String, val mindmapId: String? = null)
 @Serializable data class Timer(val userBookId: String)
 @Serializable data class BookDetail(
     val bookId: String,

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailFabEvent.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailFabEvent.kt
@@ -1,8 +1,0 @@
-package com.hihihihi.presentation.ui.bookdetail
-
-sealed class BookDetailFabEvent {
-    object NavigateToMindmap : BookDetailFabEvent()
-    object NavigateToTimer : BookDetailFabEvent()
-    object ShowAddQuoteDialog : BookDetailFabEvent()
-    object ShowAddManualHistoryDialog : BookDetailFabEvent()
-}

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailScreen.kt
@@ -283,7 +283,11 @@ private fun BookDetailPreview() {
             modifier = Modifier.fillMaxSize(),
         ) {
             BookDetailFab(
-                ReadingStatus.READING,
+                readingStatus = ReadingStatus.READING,
+                onAddQuoteClick = {},
+                onAddManualHistoryClick = {},
+                onNavigateToMindmap = {},
+                onNavigateToTimer = {},
                 modifier = Modifier
                     .align(alignment = Alignment.BottomEnd)
                     .padding(bottom = 32.dp, end = 22.dp),

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailScreen.kt
@@ -15,24 +15,22 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.hihihihi.domain.model.History
 import com.hihihihi.domain.model.Quote
 import com.hihihihi.domain.model.ReadingStatus
 import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
-import com.hihihihi.presentation.navigation.NavigationRoute
 import com.hihihihi.presentation.ui.bookdetail.components.AddManualHistoryDialog
 import com.hihihihi.presentation.ui.bookdetail.components.AddQuoteDialog
 import com.hihihihi.presentation.ui.bookdetail.components.BookCompletionDialog
@@ -52,59 +50,46 @@ import java.time.LocalDateTime
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BookDetailScreen(
-    bookId: String,  // 상세 화면에 보여줄 책 ID
-    navController: NavHostController,  // 네비게이션 컨트롤러
-    snackbarHostState: SnackbarHostState,  // 스낵바 표시 상태
-    viewModel: BookDetailViewModel = hiltViewModel(), // Hilt로 주입된 ViewModel
+    bookId: String,
+    snackbarHostState: SnackbarHostState,
+    onNavigateToMindmap: (bookId: String, mindmapId: String) -> Unit,
+    onNavigateToTimer: (bookId: String) -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: BookDetailViewModel = hiltViewModel(),
     initialShowAddQuote: Boolean = false,
     initialShowAddManualRecord: Boolean = false
 ) {
-    // ViewModel에서 관리하는 UI 상태를 Compose State로 수집
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
-    var showAddQuoteDialog by remember { mutableStateOf(initialShowAddQuote) }
-    var showAddManualHistoryDialog by remember { mutableStateOf(initialShowAddManualRecord) }
-    var showReadingStatusSheet by remember { mutableStateOf(false) }
-
-    var showEditQuoteDialog by remember { mutableStateOf<Pair<String, Quote>?>(null) }
-
-    var showCompletionDialog by remember { mutableStateOf(false) }
-
-    LaunchedEffect(bookId) {
-        viewModel.loadUserBookDetails(bookId)
-    }
-
-    LaunchedEffect(uiState.userBook) {
-        val userBook = uiState.userBook
-        if (userBook != null &&
-            userBook.status == ReadingStatus.READING &&
-            userBook.currentPage >= userBook.totalPage &&
-            userBook.currentPage > 0 &&
-            userBook.totalPage > 0
-        ) {
-            showCompletionDialog = true
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.effect.collect { effect ->
+                when (effect) {
+                    BookDetailEffect.NavigateToMindmap -> onNavigateToMindmap(bookId, bookId)
+                    BookDetailEffect.NavigateToTimer -> onNavigateToTimer(bookId)
+                }
+            }
         }
     }
 
-    // addQuoteState가 변할 때마다 실행되는 효과
+    LaunchedEffect(bookId) {
+        viewModel.loadUserBookDetails(bookId)
+        if (initialShowAddQuote) viewModel.onAddQuoteClick()
+        if (initialShowAddManualRecord) viewModel.onAddManualHistoryClick()
+    }
+
     LaunchedEffect(uiState.addQuoteState) {
         val state = uiState.addQuoteState
         when {
             state.isSuccess -> {
-                // 성공 스낵바 표시
                 Toast.makeText(context, "필사가 추가되었습니다!", Toast.LENGTH_SHORT).show()
-
-                // 상태 초기화 (중복 알림 방지)
                 viewModel.resetAddQuoteState()
             }
 
             state.error != null -> {
-                // 에러 메시지 스낵바 표시
                 Toast.makeText(context, "에러: ${state.error}", Toast.LENGTH_SHORT).show()
-
-                // 상태 초기화
                 viewModel.resetAddQuoteState()
             }
         }
@@ -125,32 +110,17 @@ fun BookDetailScreen(
                 quotes = uiState.quotes,
                 histories = uiState.histories,
                 bookStatistic = viewModel.getStatistic(),
-                onReadingStatusClick = { showReadingStatusSheet = true },
-                onReviewSave = { rating, review ->
-                    viewModel.patchReview(rating, review)
-                },
+                onReadingStatusClick = viewModel::onReadingStatusClick,
+                onReviewSave = { rating, review -> viewModel.patchReview(rating, review) },
                 onQuoteEdit = { quoteId ->
                     val quote = uiState.quotes.find { it.id == quoteId }
-                    if (quote != null) {
-                        showEditQuoteDialog = quoteId to quote
-                    }
+                    if (quote != null) viewModel.onQuoteEditClick(quoteId, quote)
                 },
                 onQuoteDelete = { id -> viewModel.deleteQuote(id) },
-                onEvent = { event ->
-                    when (event) {
-                        BookDetailFabEvent.NavigateToMindmap -> navController.navigate(
-                            NavigationRoute.MindMap.createRoute(bookId, bookId)
-                        )
-
-                        BookDetailFabEvent.NavigateToTimer -> navController.navigate(
-                            NavigationRoute.Timer.createRoute(bookId)
-                        )
-
-                        BookDetailFabEvent.ShowAddQuoteDialog -> showAddQuoteDialog = true
-                        BookDetailFabEvent.ShowAddManualHistoryDialog -> showAddManualHistoryDialog =
-                            true
-                    }
-                }
+                onAddQuoteClick = viewModel::onAddQuoteClick,
+                onAddManualHistoryClick = viewModel::onAddManualHistoryClick,
+                onNavigateToMindmap = viewModel::navigateToMindmap,
+                onNavigateToTimer = viewModel::navigateToTimer
             )
         }
 
@@ -159,92 +129,85 @@ fun BookDetailScreen(
         }
     }
 
-    showEditQuoteDialog?.let { (quoteId, quote) ->
-        EditQuoteDialog(
-            initialContent = quote.content,
-            initialPageNumber = quote.pageNumber,
-            onDismiss = { showEditQuoteDialog = null },
-            onSave = { newContent, newPageNumber ->
-                viewModel.updateQuote(
-                    quoteId = quoteId,
-                    newContent = newContent,
-                    newPageNumber = newPageNumber
-                )
-                showEditQuoteDialog = null
-            }
-        )
-    }
+    when (val dialogState = uiState.dialogState) {
+        BookDetailDialogState.None -> Unit
 
-    if (showAddQuoteDialog) {
-        AddQuoteDialog(
-            onDismiss = { showAddQuoteDialog = false },
-            onSave = { pageNumber, content ->
-                viewModel.addQuote(bookId, content, pageNumber?.toIntOrNull())
-            },
-            lastPage = uiState.userBook?.totalPage
-        )
-    }
+        is BookDetailDialogState.AddQuote -> {
+            AddQuoteDialog(
+                onDismiss = viewModel::dismissDialog,
+                onSave = { pageNumber, content ->
+                    viewModel.addQuote(bookId, content, pageNumber?.toIntOrNull())
+                },
+                lastPage = dialogState.lastPage
+            )
+        }
 
-    if (showAddManualHistoryDialog) {
-        uiState.userBook?.let {
+        is BookDetailDialogState.AddManualHistory -> {
             AddManualHistoryDialog(
-                currentPage = it.currentPage,
-                lastPage = it.totalPage,
-                uiState.userBook?.startDate,
-                onDismiss = { showAddManualHistoryDialog = false },
+                currentPage = dialogState.currentPage,
+                lastPage = dialogState.lastPage,
+                startDate = dialogState.startDate,
+                onDismiss = viewModel::dismissDialog,
                 onSave = { date, startTime, endTime, readTime, readPageCount, currentPage ->
-                    viewModel.addManualHistory(
-                        date,
-                        startTime,
-                        endTime,
-                        readTime,
-                        readPageCount,
-                        currentPage
-                    )
-                    showAddManualHistoryDialog = false
+                    viewModel.addManualHistory(date, startTime, endTime, readTime, readPageCount, currentPage)
+                    viewModel.dismissDialog()
                 }
             )
         }
-    }
 
-    if (showReadingStatusSheet && uiState.userBook != null) {
-        SetReadingStatusBottomSheet(
-            userBook = uiState.userBook!!,
-            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-            onDismiss = { showReadingStatusSheet = false },
-            onConfirm = { status, page, startDate, endDate ->
-                // 상태 변경 로직 호출
-                viewModel.patchUserBook(status, page, startDate, endDate)
-                showReadingStatusSheet = false
-            }
-        )
-    }
-
-    if (showCompletionDialog && uiState.userBook != null) {
-        BookCompletionDialog(
-            userBook = uiState.userBook!!,
-            onConfirm = {
-                val userBook = uiState.userBook!!
-
-                val endDate: LocalDateTime = uiState.histories
-                    .mapNotNull { it.endTime }
-                    .maxOrNull()
-                    ?: LocalDateTime.now()
-
-                viewModel.patchUserBook(
-                    status = ReadingStatus.FINISHED,
-                    page = userBook.totalPage,
-                    startDate = userBook.startDate,
-                    endDate = endDate
+        BookDetailDialogState.ReadingStatus -> {
+            if (uiState.userBook != null) {
+                SetReadingStatusBottomSheet(
+                    userBook = uiState.userBook!!,
+                    sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                    onDismiss = viewModel::dismissDialog,
+                    onConfirm = { status, page, startDate, endDate ->
+                        viewModel.patchUserBook(status, page, startDate, endDate)
+                        viewModel.dismissDialog()
+                    }
                 )
-                showCompletionDialog = false
-
-                Toast.makeText(context, "🎉 완독을 축하드립니다!", Toast.LENGTH_LONG).show()
-            },
-            onDismiss = {
-                showCompletionDialog = false
             }
-        )
+        }
+
+        is BookDetailDialogState.EditQuote -> {
+            EditQuoteDialog(
+                initialContent = dialogState.quote.content,
+                initialPageNumber = dialogState.quote.pageNumber,
+                onDismiss = viewModel::dismissDialog,
+                onSave = { newContent, newPageNumber ->
+                    viewModel.updateQuote(
+                        quoteId = dialogState.quoteId,
+                        newContent = newContent,
+                        newPageNumber = newPageNumber
+                    )
+                    viewModel.dismissDialog()
+                }
+            )
+        }
+
+        BookDetailDialogState.Completion -> {
+            if (uiState.userBook != null) {
+                BookCompletionDialog(
+                    userBook = uiState.userBook!!,
+                    onConfirm = {
+                        val userBook = uiState.userBook!!
+                        val endDate: LocalDateTime = uiState.histories
+                            .mapNotNull { it.endTime }
+                            .maxOrNull()
+                            ?: LocalDateTime.now()
+                        viewModel.patchUserBook(
+                            status = ReadingStatus.FINISHED,
+                            page = userBook.totalPage,
+                            startDate = userBook.startDate,
+                            endDate = endDate
+                        )
+                        viewModel.dismissDialog()
+                        Toast.makeText(context, "🎉 완독을 축하드립니다!", Toast.LENGTH_LONG).show()
+                    },
+                    onDismiss = viewModel::dismissDialog
+                )
+            }
+        }
     }
 }
 
@@ -255,11 +218,13 @@ fun BookDetailContent(
     histories: List<History>,
     bookStatistic: BookStatistic,
     onReadingStatusClick: () -> Unit,
-    onEvent: (BookDetailFabEvent) -> Unit = {},
+    onAddQuoteClick: () -> Unit = {},
+    onAddManualHistoryClick: () -> Unit = {},
+    onNavigateToMindmap: () -> Unit = {},
+    onNavigateToTimer: () -> Unit = {},
     onReviewSave: (Double, String) -> Unit = { _, _ -> },
     onQuoteEdit: (String) -> Unit = {},
     onQuoteDelete: (String) -> Unit = {}
-
 ) {
     val scrollState = rememberLazyListState()
 
@@ -280,9 +245,7 @@ fun BookDetailContent(
                     ReviewSection(
                         initialRating = userBook.rating?.toFloat() ?: 0f,
                         initialReview = userBook.review ?: "",
-                        onSave = { rating, review ->
-                            onReviewSave(rating, review)
-                        }
+                        onSave = { rating, review -> onReviewSave(rating, review) }
                     )
                 }
             }
@@ -298,10 +261,12 @@ fun BookDetailContent(
             }
         }
 
-        // FAB
         BookDetailFab(
-            userBook.status,
-            onEvent = onEvent,
+            readingStatus = userBook.status,
+            onAddQuoteClick = onAddQuoteClick,
+            onAddManualHistoryClick = onAddManualHistoryClick,
+            onNavigateToMindmap = onNavigateToMindmap,
+            onNavigateToTimer = onNavigateToTimer,
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .navigationBarsPadding()
@@ -322,7 +287,6 @@ private fun BookDetailPreview() {
                 modifier = Modifier
                     .align(alignment = Alignment.BottomEnd)
                     .padding(bottom = 32.dp, end = 22.dp),
-                onEvent = { }
             )
 
             LazyColumn(
@@ -331,7 +295,6 @@ private fun BookDetailPreview() {
                 item { BookSimpleInfoSection(dummyUserBook, {}) }
                 item { ReadingProgressSection(dummyUserBook) }
                 item { BookStatisticsCard(BookStatistic("", "", "")) }
-//                item { BookDetailTabs(dummyUserBook, dummyQuotes, dummyRecords) }
             }
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -60,7 +60,7 @@ fun BookDetailScreen(
     initialShowAddManualRecord: Boolean = false
 ) {
     // ViewModel에서 관리하는 UI 상태를 Compose State로 수집
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailScreen.kt
@@ -26,10 +26,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
-import com.hihihihi.domain.model.History
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.domain.model.ReadingStatus
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.ui.bookdetail.components.AddManualHistoryDialog
 import com.hihihihi.presentation.ui.bookdetail.components.AddQuoteDialog
@@ -45,6 +42,9 @@ import com.hihihihi.presentation.ui.bookdetail.components.SetReadingStatusBottom
 import com.hihihihi.presentation.ui.bookdetail.mock.dummyUserBook
 import com.hihihihi.presentation.ui.home.components.ErrorView
 import com.hihihihi.presentation.ui.home.components.LoadingView
+import com.hihihihi.presentation.ui.model.HistoryUiModel
+import com.hihihihi.presentation.ui.model.QuoteUiModel
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 import java.time.LocalDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -57,7 +57,7 @@ fun BookDetailScreen(
     onNavigateBack: () -> Unit,
     viewModel: BookDetailViewModel = hiltViewModel(),
     initialShowAddQuote: Boolean = false,
-    initialShowAddManualRecord: Boolean = false
+    initialShowAddManualRecord: Boolean = false,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -113,14 +113,14 @@ fun BookDetailScreen(
                 onReadingStatusClick = viewModel::onReadingStatusClick,
                 onReviewSave = { rating, review -> viewModel.patchReview(rating, review) },
                 onQuoteEdit = { quoteId ->
-                    val quote = uiState.quotes.find { it.id == quoteId }
-                    if (quote != null) viewModel.onQuoteEditClick(quoteId, quote)
+                    val quoteUiModel = uiState.quotes.find { it.id == quoteId }
+                    if (quoteUiModel != null) viewModel.onQuoteEditClick(quoteUiModel)
                 },
                 onQuoteDelete = { id -> viewModel.deleteQuote(id) },
                 onAddQuoteClick = viewModel::onAddQuoteClick,
                 onAddManualHistoryClick = viewModel::onAddManualHistoryClick,
                 onNavigateToMindmap = viewModel::navigateToMindmap,
-                onNavigateToTimer = viewModel::navigateToTimer
+                onNavigateToTimer = viewModel::navigateToTimer,
             )
         }
 
@@ -138,7 +138,7 @@ fun BookDetailScreen(
                 onSave = { pageNumber, content ->
                     viewModel.addQuote(bookId, content, pageNumber?.toIntOrNull())
                 },
-                lastPage = dialogState.lastPage
+                lastPage = dialogState.lastPage,
             )
         }
 
@@ -151,7 +151,7 @@ fun BookDetailScreen(
                 onSave = { date, startTime, endTime, readTime, readPageCount, currentPage ->
                     viewModel.addManualHistory(date, startTime, endTime, readTime, readPageCount, currentPage)
                     viewModel.dismissDialog()
-                }
+                },
             )
         }
 
@@ -164,24 +164,24 @@ fun BookDetailScreen(
                     onConfirm = { status, page, startDate, endDate ->
                         viewModel.patchUserBook(status, page, startDate, endDate)
                         viewModel.dismissDialog()
-                    }
+                    },
                 )
             }
         }
 
         is BookDetailDialogState.EditQuote -> {
             EditQuoteDialog(
-                initialContent = dialogState.quote.content,
-                initialPageNumber = dialogState.quote.pageNumber,
+                initialContent = dialogState.quoteUiModel.content,
+                initialPageNumber = dialogState.quoteUiModel.pageNumber,
                 onDismiss = viewModel::dismissDialog,
                 onSave = { newContent, newPageNumber ->
                     viewModel.updateQuote(
-                        quoteId = dialogState.quoteId,
+                        quoteId = dialogState.quoteUiModel.id,
                         newContent = newContent,
-                        newPageNumber = newPageNumber
+                        newPageNumber = newPageNumber,
                     )
                     viewModel.dismissDialog()
-                }
+                },
             )
         }
 
@@ -199,12 +199,12 @@ fun BookDetailScreen(
                             status = ReadingStatus.FINISHED,
                             page = userBook.totalPage,
                             startDate = userBook.startDate,
-                            endDate = endDate
+                            endDate = endDate,
                         )
                         viewModel.dismissDialog()
                         Toast.makeText(context, "🎉 완독을 축하드립니다!", Toast.LENGTH_LONG).show()
                     },
-                    onDismiss = viewModel::dismissDialog
+                    onDismiss = viewModel::dismissDialog,
                 )
             }
         }
@@ -213,9 +213,9 @@ fun BookDetailScreen(
 
 @Composable
 fun BookDetailContent(
-    userBook: UserBook,
-    quotes: List<Quote>,
-    histories: List<History>,
+    userBook: UserBookUiModel,
+    quotes: List<QuoteUiModel>,
+    histories: List<HistoryUiModel>,
     bookStatistic: BookStatistic,
     onReadingStatusClick: () -> Unit,
     onAddQuoteClick: () -> Unit = {},
@@ -224,7 +224,7 @@ fun BookDetailContent(
     onNavigateToTimer: () -> Unit = {},
     onReviewSave: (Double, String) -> Unit = { _, _ -> },
     onQuoteEdit: (String) -> Unit = {},
-    onQuoteDelete: (String) -> Unit = {}
+    onQuoteDelete: (String) -> Unit = {},
 ) {
     val scrollState = rememberLazyListState()
 
@@ -245,7 +245,7 @@ fun BookDetailContent(
                     ReviewSection(
                         initialRating = userBook.rating?.toFloat() ?: 0f,
                         initialReview = userBook.review ?: "",
-                        onSave = { rating, review -> onReviewSave(rating, review) }
+                        onSave = { rating, review -> onReviewSave(rating, review) },
                     )
                 }
             }
@@ -255,7 +255,7 @@ fun BookDetailContent(
                     quotes = quotes,
                     histories = histories,
                     onQuoteEdit = onQuoteEdit,
-                    onQuoteDelete = onQuoteDelete
+                    onQuoteDelete = onQuoteDelete,
                 )
                 Spacer(Modifier.height(50.dp))
             }
@@ -269,7 +269,7 @@ fun BookDetailContent(
             onNavigateToTimer = onNavigateToTimer,
             modifier = Modifier
                 .align(Alignment.BottomEnd)
-                .navigationBarsPadding()
+                .navigationBarsPadding(),
         )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailUiState.kt
@@ -11,7 +11,8 @@ data class BookDetailUiState(
     val errorMessage: String? = null,       // 에러 메시지 (null이면 에러 없음)
     val quotes: List<Quote> = emptyList(),  // 필사 목록
     val histories: List<History> = emptyList(), // 읽은 책 목록
-    val addQuoteState: AddQuoteState = AddQuoteState()  // 필사 추가 상태 관리 객체
+    val addQuoteState: AddQuoteState = AddQuoteState(),  // 필사 추가 상태 관리 객체
+    val dialogState: BookDetailDialogState = BookDetailDialogState.None
 )
 
 // 필사 추가 작업에 대한 상태를 별도로 관리하기 위한 클래스

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailUiState.kt
@@ -1,24 +1,22 @@
 package com.hihihihi.presentation.ui.bookdetail
 
-import com.hihihihi.domain.model.History
-import com.hihihihi.domain.model.Quote
-import com.hihihihi.domain.model.UserBook
+import com.hihihihi.presentation.ui.model.HistoryUiModel
+import com.hihihihi.presentation.ui.model.QuoteUiModel
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 
-// 도서 상세 화면 UI 상태를 담는 데이터 클래스
 data class BookDetailUiState(
-    val userBook: UserBook? = null,                // 사용자가 등록한 책 정보 (없을 수도 있음)
-    val isLoading: Boolean = false,         // 화면 전체 로딩 상태 여부
-    val errorMessage: String? = null,       // 에러 메시지 (null이면 에러 없음)
-    val quotes: List<Quote> = emptyList(),  // 필사 목록
-    val histories: List<History> = emptyList(), // 읽은 책 목록
-    val addQuoteState: AddQuoteState = AddQuoteState(),  // 필사 추가 상태 관리 객체
-    val dialogState: BookDetailDialogState = BookDetailDialogState.None
+    val userBook: UserBookUiModel? = null,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    val quotes: List<QuoteUiModel> = emptyList(),
+    val histories: List<HistoryUiModel> = emptyList(),
+    val addQuoteState: AddQuoteState = AddQuoteState(),
+    val dialogState: BookDetailDialogState = BookDetailDialogState.None,
 )
 
-// 필사 추가 작업에 대한 상태를 별도로 관리하기 위한 클래스
 data class AddQuoteState(
-    val isLoading: Boolean = false,    // 필사 추가 요청 중인지 여부
-    val isSuccess: Boolean = false,    // 필사 추가 성공 여부
-    val error: String? = null,         // 필사 추가 중 발생한 에러 메시지
-    val message: String? = null        // (필요 시) 추가적인 성공/정보 메시지
+    val isLoading: Boolean = false,
+    val isSuccess: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailViewModel.kt
@@ -6,6 +6,7 @@ import com.hihihihi.domain.model.History
 import com.hihihihi.domain.model.Quote
 import com.hihihihi.domain.model.ReadingStatus
 import com.hihihihi.domain.model.RecordType
+import com.hihihihi.domain.model.UserBook
 import com.hihihihi.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.hihihihi.domain.usecase.history.AddHistoryUseCase
 import com.hihihihi.domain.usecase.quote.AddQuoteUseCase
@@ -13,6 +14,8 @@ import com.hihihihi.domain.usecase.quote.DeleteQuoteUseCase
 import com.hihihihi.domain.usecase.quote.UpdateQuoteUseCase
 import com.hihihihi.domain.usecase.userbook.GetBookDetailDataUseCase
 import com.hihihihi.domain.usecase.userbook.PatchUserBookUseCase
+import com.hihihihi.presentation.ui.model.QuoteUiModel
+import com.hihihihi.presentation.ui.model.toUiModel
 import com.hihihihi.presentation.utils.formatSecondsToReadableTime
 import com.hihihihi.presentation.utils.getDailyAverageReadTimeInSeconds
 import com.hihihihi.presentation.utils.getDayCountLabel
@@ -38,7 +41,7 @@ class BookDetailViewModel @Inject constructor(
     private val getBookDetailDataUseCase: GetBookDetailDataUseCase,
     private val deleteQuoteUseCase: DeleteQuoteUseCase,
     private val updateQuoteUseCase: UpdateQuoteUseCase,
-    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(BookDetailUiState())
@@ -46,6 +49,10 @@ class BookDetailViewModel @Inject constructor(
 
     private val _effect = Channel<BookDetailEffect>(Channel.BUFFERED)
     val effect: Flow<BookDetailEffect> = _effect.receiveAsFlow()
+
+    // domain 백킹 — mutation 연산(patchUserBook, addQuote, addManualHistory)에서 사용
+    private var _domainUserBook: UserBook? = null
+    private var _domainHistories: List<History> = emptyList()
 
     private val currentUid: String?
         get() = getCurrentUserIdUseCase()
@@ -57,6 +64,9 @@ class BookDetailViewModel @Inject constructor(
                 .catch { e -> _uiState.update { it.copy(errorMessage = e.message, isLoading = false) } }
                 .collect { data ->
                     val userBook = data.userBook
+                    _domainUserBook = userBook
+                    _domainHistories = data.history
+
                     val shouldShowCompletion = userBook != null &&
                             userBook.status == ReadingStatus.READING &&
                             userBook.currentPage >= userBook.totalPage &&
@@ -65,15 +75,15 @@ class BookDetailViewModel @Inject constructor(
 
                     _uiState.update {
                         it.copy(
-                            userBook = userBook,
-                            quotes = data.quotes,
-                            histories = data.history,
+                            userBook = userBook?.toUiModel(),
+                            quotes = data.quotes.map { q -> q.toUiModel() },
+                            histories = data.history.map { h -> h.toUiModel() },
                             isLoading = false,
                             dialogState = if (shouldShowCompletion && it.dialogState == BookDetailDialogState.None) {
                                 BookDetailDialogState.Completion
                             } else {
                                 it.dialogState
-                            }
+                            },
                         )
                     }
                 }
@@ -87,14 +97,14 @@ class BookDetailViewModel @Inject constructor(
     }
 
     fun onAddManualHistoryClick() {
-        val userBook = _uiState.value.userBook
+        val userBook = _domainUserBook
         _uiState.update {
             it.copy(
                 dialogState = BookDetailDialogState.AddManualHistory(
                     currentPage = userBook?.currentPage ?: 0,
                     lastPage = userBook?.totalPage ?: 0,
-                    startDate = userBook?.startDate
-                )
+                    startDate = userBook?.startDate,
+                ),
             )
         }
     }
@@ -103,8 +113,8 @@ class BookDetailViewModel @Inject constructor(
         _uiState.update { it.copy(dialogState = BookDetailDialogState.ReadingStatus) }
     }
 
-    fun onQuoteEditClick(quoteId: String, quote: Quote) {
-        _uiState.update { it.copy(dialogState = BookDetailDialogState.EditQuote(quoteId, quote)) }
+    fun onQuoteEditClick(quoteUiModel: QuoteUiModel) {
+        _uiState.update { it.copy(dialogState = BookDetailDialogState.EditQuote(quoteUiModel)) }
     }
 
     fun dismissDialog() {
@@ -129,9 +139,9 @@ class BookDetailViewModel @Inject constructor(
         endTime: LocalDateTime,
         readTime: Int,
         readPageCount: Int,
-        currentPage: Int
+        currentPage: Int,
     ) {
-        val userBook = uiState.value.userBook ?: return
+        val userBook = _domainUserBook ?: return
         val uid = currentUid ?: return
 
         val history = History(
@@ -143,7 +153,7 @@ class BookDetailViewModel @Inject constructor(
             endTime = endTime,
             readTime = readTime,
             readPageCount = readPageCount,
-            recordType = RecordType.MANUAL
+            recordType = RecordType.MANUAL,
         )
 
         viewModelScope.launch {
@@ -156,7 +166,7 @@ class BookDetailViewModel @Inject constructor(
     }
 
     fun addQuote(userBookId: String, content: String, pageNumber: Int?) {
-        val userBook = uiState.value.userBook ?: return
+        val userBook = _domainUserBook ?: return
         val uid = currentUid ?: return
 
         val newQuote = Quote(
@@ -170,7 +180,7 @@ class BookDetailViewModel @Inject constructor(
             title = userBook.title,
             author = userBook.author,
             publisher = userBook.publisher ?: "",
-            imageUrl = userBook.imageUrl
+            imageUrl = userBook.imageUrl,
         )
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(addQuoteState = AddQuoteState(isLoading = true))
@@ -181,7 +191,7 @@ class BookDetailViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(addQuoteState = AddQuoteState())
             } else if (result.isFailure) {
                 _uiState.value = _uiState.value.copy(
-                    addQuoteState = AddQuoteState(error = result.exceptionOrNull()?.message ?: "알 수 없는 오류")
+                    addQuoteState = AddQuoteState(error = result.exceptionOrNull()?.message ?: "알 수 없는 오류"),
                 )
             }
         }
@@ -192,32 +202,33 @@ class BookDetailViewModel @Inject constructor(
     }
 
     fun getStatistic(): BookStatistic {
+        val userBook = _domainUserBook
         return BookStatistic(
-            readingPeriod = if (uiState.value.userBook?.startDate == null) "아직 읽지 않은 책" else getDayCountLabel(
-                uiState.value.userBook?.startDate!!,
-                uiState.value.userBook?.endDate,
-                uiState.value.userBook?.status!!
+            readingPeriod = if (userBook?.startDate == null) "아직 읽지 않은 책" else getDayCountLabel(
+                userBook.startDate!!,
+                userBook.endDate,
+                userBook.status,
             ),
-            totalReadingTime = uiState.value.histories
+            totalReadingTime = _domainHistories
                 .sumOf { it.readTime }
                 .let { if (it == 0) "0분" else formatSecondsToReadableTime(it) },
-            averageDailyTime = getDailyAverageReadTimeInSeconds(uiState.value.histories)
+            averageDailyTime = getDailyAverageReadTimeInSeconds(_domainHistories),
         )
     }
 
     fun patchUserBook(status: ReadingStatus?, page: Int?, startDate: LocalDateTime?, endDate: LocalDateTime?) {
-        val userBook = uiState.value.userBook ?: return
+        val userBook = _domainUserBook ?: return
         val patchUserBook = userBook.copy(
             status = status ?: userBook.status,
             currentPage = page ?: userBook.currentPage,
             startDate = startDate ?: userBook.startDate,
-            endDate = endDate ?: userBook.endDate
+            endDate = endDate ?: userBook.endDate,
         )
         viewModelScope.launch { patchUserBookUseCase(patchUserBook) }
     }
 
     fun patchReview(rating: Double, review: String) {
-        val userBook = uiState.value.userBook ?: return
+        val userBook = _domainUserBook ?: return
         val patchUserBook = userBook.copy(rating = rating, review = review)
         viewModelScope.launch { patchUserBookUseCase(patchUserBook) }
     }
@@ -253,7 +264,7 @@ class BookDetailViewModel @Inject constructor(
 data class BookStatistic(
     val readingPeriod: String,
     val totalReadingTime: String,
-    val averageDailyTime: String
+    val averageDailyTime: String,
 )
 
 sealed interface BookDetailDialogState {
@@ -262,11 +273,11 @@ sealed interface BookDetailDialogState {
     data class AddManualHistory(
         val currentPage: Int,
         val lastPage: Int,
-        val startDate: LocalDateTime?
+        val startDate: LocalDateTime?,
     ) : BookDetailDialogState
 
     data object ReadingStatus : BookDetailDialogState
-    data class EditQuote(val quoteId: String, val quote: Quote) : BookDetailDialogState
+    data class EditQuote(val quoteUiModel: QuoteUiModel) : BookDetailDialogState
     data object Completion : BookDetailDialogState
 }
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailViewModel.kt
@@ -204,11 +204,11 @@ class BookDetailViewModel @Inject constructor(
     fun getStatistic(): BookStatistic {
         val userBook = _domainUserBook
         return BookStatistic(
-            readingPeriod = if (userBook?.startDate == null) "아직 읽지 않은 책" else getDayCountLabel(
-                userBook.startDate!!,
-                userBook.endDate,
-                userBook.status,
-            ),
+            readingPeriod = userBook?.let { book ->
+                val startDate = book.startDate
+                if (startDate == null) "아직 읽지 않은 책"
+                else getDayCountLabel(startDate, book.endDate, book.status)
+            } ?: "아직 읽지 않은 책",
             totalReadingTime = _domainHistories
                 .sumOf { it.readTime }
                 .let { if (it == 0) "0분" else formatSecondsToReadableTime(it) },

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/BookDetailViewModel.kt
@@ -17,11 +17,14 @@ import com.hihihihi.presentation.utils.formatSecondsToReadableTime
 import com.hihihihi.presentation.utils.getDailyAverageReadTimeInSeconds
 import com.hihihihi.presentation.utils.getDayCountLabel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
@@ -38,13 +41,14 @@ class BookDetailViewModel @Inject constructor(
     private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
 ) : ViewModel() {
 
-    // UI 상태를 관리하는 StateFlow
     private val _uiState = MutableStateFlow(BookDetailUiState())
     val uiState: StateFlow<BookDetailUiState> = _uiState
 
+    private val _effect = Channel<BookDetailEffect>(Channel.BUFFERED)
+    val effect: Flow<BookDetailEffect> = _effect.receiveAsFlow()
+
     private val currentUid: String?
         get() = getCurrentUserIdUseCase()
-
 
     fun loadUserBookDetails(userBookId: String) {
         viewModelScope.launch {
@@ -52,17 +56,72 @@ class BookDetailViewModel @Inject constructor(
                 .onStart { _uiState.update { it.copy(isLoading = true) } }
                 .catch { e -> _uiState.update { it.copy(errorMessage = e.message, isLoading = false) } }
                 .collect { data ->
+                    val userBook = data.userBook
+                    val shouldShowCompletion = userBook != null &&
+                            userBook.status == ReadingStatus.READING &&
+                            userBook.currentPage >= userBook.totalPage &&
+                            userBook.currentPage > 0 &&
+                            userBook.totalPage > 0
+
                     _uiState.update {
                         it.copy(
-                            userBook = data.userBook,
+                            userBook = userBook,
                             quotes = data.quotes,
                             histories = data.history,
-                            isLoading = false
+                            isLoading = false,
+                            dialogState = if (shouldShowCompletion && it.dialogState == BookDetailDialogState.None) {
+                                BookDetailDialogState.Completion
+                            } else {
+                                it.dialogState
+                            }
                         )
                     }
                 }
         }
     }
+
+    // --- Dialog 상태 메서드 ---
+
+    fun onAddQuoteClick() {
+        _uiState.update { it.copy(dialogState = BookDetailDialogState.AddQuote(it.userBook?.totalPage)) }
+    }
+
+    fun onAddManualHistoryClick() {
+        val userBook = _uiState.value.userBook
+        _uiState.update {
+            it.copy(
+                dialogState = BookDetailDialogState.AddManualHistory(
+                    currentPage = userBook?.currentPage ?: 0,
+                    lastPage = userBook?.totalPage ?: 0,
+                    startDate = userBook?.startDate
+                )
+            )
+        }
+    }
+
+    fun onReadingStatusClick() {
+        _uiState.update { it.copy(dialogState = BookDetailDialogState.ReadingStatus) }
+    }
+
+    fun onQuoteEditClick(quoteId: String, quote: Quote) {
+        _uiState.update { it.copy(dialogState = BookDetailDialogState.EditQuote(quoteId, quote)) }
+    }
+
+    fun dismissDialog() {
+        _uiState.update { it.copy(dialogState = BookDetailDialogState.None) }
+    }
+
+    // --- Navigation Effect 메서드 ---
+
+    fun navigateToMindmap() {
+        viewModelScope.launch { _effect.send(BookDetailEffect.NavigateToMindmap) }
+    }
+
+    fun navigateToTimer() {
+        viewModelScope.launch { _effect.send(BookDetailEffect.NavigateToTimer) }
+    }
+
+    // --- 데이터 조작 메서드 ---
 
     fun addManualHistory(
         date: LocalDateTime,
@@ -73,7 +132,6 @@ class BookDetailViewModel @Inject constructor(
         currentPage: Int
     ) {
         val userBook = uiState.value.userBook ?: return
-
         val uid = currentUid ?: return
 
         val history = History(
@@ -92,17 +150,13 @@ class BookDetailViewModel @Inject constructor(
             try {
                 addHistoryUseCase(history, currentPage = currentPage)
             } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(errorMessage = e.message)
-                }
+                _uiState.update { it.copy(errorMessage = e.message) }
             }
         }
     }
 
-
     fun addQuote(userBookId: String, content: String, pageNumber: Int?) {
-        val userBook = uiState.value.userBook ?: return // 방어 코드
-
+        val userBook = uiState.value.userBook ?: return
         val uid = currentUid ?: return
 
         val newQuote = Quote(
@@ -119,34 +173,24 @@ class BookDetailViewModel @Inject constructor(
             imageUrl = userBook.imageUrl
         )
         viewModelScope.launch {
-            // 로딩 상태로 설정
             _uiState.value = _uiState.value.copy(addQuoteState = AddQuoteState(isLoading = true))
-
-            // 명언 추가 UseCase 실행
             val result = addQuoteUseCase(newQuote)
-
-            // 결과에 따라 상태 업데이트
             if (result.isSuccess) {
                 _uiState.value = _uiState.value.copy(addQuoteState = AddQuoteState(isSuccess = true))
-                delay(2000) // 잠깐 보여주기 위한 delay (필요에 따라 조절 가능)
+                delay(2000)
                 _uiState.value = _uiState.value.copy(addQuoteState = AddQuoteState())
             } else if (result.isFailure) {
                 _uiState.value = _uiState.value.copy(
-                    addQuoteState = AddQuoteState(
-                        error = result.exceptionOrNull()?.message ?: "알 수 없는 오류"
-                    )
+                    addQuoteState = AddQuoteState(error = result.exceptionOrNull()?.message ?: "알 수 없는 오류")
                 )
             }
-
         }
     }
 
-    // 필사 추가 상태 초기화 함수
     fun resetAddQuoteState() {
         _uiState.value = _uiState.value.copy(addQuoteState = AddQuoteState())
     }
 
-    // 통계 반환하는 함수
     fun getStatistic(): BookStatistic {
         return BookStatistic(
             readingPeriod = if (uiState.value.userBook?.startDate == null) "아직 읽지 않은 책" else getDayCountLabel(
@@ -163,39 +207,26 @@ class BookDetailViewModel @Inject constructor(
 
     fun patchUserBook(status: ReadingStatus?, page: Int?, startDate: LocalDateTime?, endDate: LocalDateTime?) {
         val userBook = uiState.value.userBook ?: return
-
         val patchUserBook = userBook.copy(
             status = status ?: userBook.status,
             currentPage = page ?: userBook.currentPage,
             startDate = startDate ?: userBook.startDate,
             endDate = endDate ?: userBook.endDate
         )
-
-        viewModelScope.launch {
-            patchUserBookUseCase(patchUserBook)
-        }
+        viewModelScope.launch { patchUserBookUseCase(patchUserBook) }
     }
 
     fun patchReview(rating: Double, review: String) {
         val userBook = uiState.value.userBook ?: return
-
-        val patchUserBook = userBook.copy(
-            rating = rating,
-            review = review
-        )
-
-        viewModelScope.launch {
-            patchUserBookUseCase(patchUserBook)
-        }
+        val patchUserBook = userBook.copy(rating = rating, review = review)
+        viewModelScope.launch { patchUserBookUseCase(patchUserBook) }
     }
 
     fun deleteQuote(quoteId: String) {
         viewModelScope.launch {
             val result = deleteQuoteUseCase(quoteId)
             if (result.isSuccess) {
-                _uiState.update { state ->
-                    state.copy(quotes = state.quotes.filterNot { it.id == quoteId })
-                }
+                _uiState.update { state -> state.copy(quotes = state.quotes.filterNot { it.id == quoteId }) }
             } else {
                 _uiState.update { it.copy(errorMessage = result.exceptionOrNull()?.message) }
             }
@@ -206,13 +237,9 @@ class BookDetailViewModel @Inject constructor(
         val currentQuotes = uiState.value.quotes.toMutableList()
         val index = currentQuotes.indexOfFirst { it.id == quoteId }
         if (index != -1) {
-            val updatedQuote = currentQuotes[index].copy(
-                content = newContent,
-                pageNumber = newPageNumber
-            )
+            val updatedQuote = currentQuotes[index].copy(content = newContent, pageNumber = newPageNumber)
             currentQuotes[index] = updatedQuote
             _uiState.update { it.copy(quotes = currentQuotes) }
-
             viewModelScope.launch {
                 val result = updateQuoteUseCase(quoteId, newContent, newPageNumber)
                 if (result.isFailure) {
@@ -229,3 +256,21 @@ data class BookStatistic(
     val averageDailyTime: String
 )
 
+sealed interface BookDetailDialogState {
+    data object None : BookDetailDialogState
+    data class AddQuote(val lastPage: Int?) : BookDetailDialogState
+    data class AddManualHistory(
+        val currentPage: Int,
+        val lastPage: Int,
+        val startDate: LocalDateTime?
+    ) : BookDetailDialogState
+
+    data object ReadingStatus : BookDetailDialogState
+    data class EditQuote(val quoteId: String, val quote: Quote) : BookDetailDialogState
+    data object Completion : BookDetailDialogState
+}
+
+sealed interface BookDetailEffect {
+    data object NavigateToMindmap : BookDetailEffect
+    data object NavigateToTimer : BookDetailEffect
+}

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookCompletionDialog.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookCompletionDialog.kt
@@ -25,7 +25,6 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.designsystem.components.BookCoverImage
 import com.hihihihi.presentation.designsystem.components.GureumButton
 import com.hihihihi.presentation.designsystem.components.GureumCancelButton
@@ -34,20 +33,21 @@ import com.hihihihi.presentation.designsystem.components.Medi12Text
 import com.hihihihi.presentation.designsystem.components.Medi14Text
 import com.hihihihi.presentation.designsystem.components.Semi16Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 
 @Composable
 fun BookCompletionDialog(
-    userBook: UserBook,
+    userBook: UserBookUiModel,
     onConfirm: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
     val confettiComposition by rememberLottieComposition(
-        LottieCompositionSpec.Asset("confetti.json")
+        LottieCompositionSpec.Asset("confetti.json"),
     )
 
     val confettiProgress by animateLottieCompositionAsState(
         composition = confettiComposition,
-        iterations = 1
+        iterations = 1,
     )
 
     val isConfettiFinished = confettiProgress == 1f
@@ -57,8 +57,8 @@ fun BookCompletionDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(
             dismissOnBackPress = true,
-            dismissOnClickOutside = true
-        )
+            dismissOnClickOutside = true,
+        ),
     ) {
         Box {
             GureumCard(
@@ -70,7 +70,7 @@ fun BookCompletionDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Semi16Text(
                         text = "🎉 축하합니다! 🎉",
@@ -83,7 +83,7 @@ fun BookCompletionDialog(
                     Medi14Text(
                         text = "책을 모두 읽으셨네요!",
                         color = GureumTheme.colors.gray800,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
 
                     Spacer(modifier = Modifier.height(16.dp))
@@ -102,14 +102,14 @@ fun BookCompletionDialog(
                         text = userBook.title,
                         color = GureumTheme.colors.gray800,
                         maxLine = 2,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
 
                     Medi12Text(
                         text = userBook.author,
                         color = GureumTheme.colors.gray700,
                         maxLine = 1,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))
@@ -117,7 +117,7 @@ fun BookCompletionDialog(
                     Medi12Text(
                         text = "${userBook.currentPage} / ${userBook.totalPage} 페이지 완독",
                         color = GureumTheme.colors.primary,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
 
                     Spacer(modifier = Modifier.height(24.dp))
@@ -125,14 +125,14 @@ fun BookCompletionDialog(
                     Medi14Text(
                         text = "책 상태를 '읽은 책'으로 변경하시겠습니까?",
                         color = GureumTheme.colors.gray800,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
 
                     Spacer(modifier = Modifier.height(20.dp))
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         GureumCancelButton(
                             "나중에",
@@ -158,7 +158,7 @@ fun BookCompletionDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(200.dp)
-                        .align(Alignment.TopCenter)
+                        .align(Alignment.TopCenter),
                 )
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookDetailFab.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookDetailFab.kt
@@ -49,10 +49,10 @@ import com.hihihihi.presentation.designsystem.theme.GureumTheme
 fun BookDetailFab(
     readingStatus: ReadingStatus,
     modifier: Modifier = Modifier,
-    onAddQuoteClick: () -> Unit = {},
-    onAddManualHistoryClick: () -> Unit = {},
-    onNavigateToMindmap: () -> Unit = {},
-    onNavigateToTimer: () -> Unit = {}
+    onAddQuoteClick: () -> Unit,
+    onAddManualHistoryClick: () -> Unit,
+    onNavigateToMindmap: () -> Unit,
+    onNavigateToTimer: () -> Unit,
 ) {
     var fabExpanded by remember { mutableStateOf(false) }
 
@@ -182,6 +182,12 @@ data class MiniFabItem(
 @Composable
 private fun BookDetailFabPreview() {
     GureumPageTheme {
-        BookDetailFab(readingStatus = ReadingStatus.READING)
+        BookDetailFab(
+            readingStatus = ReadingStatus.READING,
+            onAddQuoteClick = {},
+            onAddManualHistoryClick = {},
+            onNavigateToMindmap = {},
+            onNavigateToTimer = {},
+        )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookDetailFab.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookDetailFab.kt
@@ -44,46 +44,30 @@ import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.Medi12Text
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
-import com.hihihihi.presentation.ui.bookdetail.BookDetailFabEvent
 
 @Composable
 fun BookDetailFab(
     readingStatus: ReadingStatus,
     modifier: Modifier = Modifier,
-    onEvent: (BookDetailFabEvent) -> Unit
+    onAddQuoteClick: () -> Unit = {},
+    onAddManualHistoryClick: () -> Unit = {},
+    onNavigateToMindmap: () -> Unit = {},
+    onNavigateToTimer: () -> Unit = {}
 ) {
     var fabExpanded by remember { mutableStateOf(false) }
 
     val fabItems = when (readingStatus) {
         ReadingStatus.PLANNED -> emptyList()
         ReadingStatus.READING -> listOf(
-            MiniFabItem(
-                R.drawable.ic_lightbulb_filled,
-                "필사 추가"
-            ) { onEvent(BookDetailFabEvent.ShowAddQuoteDialog) },
-            MiniFabItem(
-                R.drawable.ic_graph,
-                "마인드맵 그리기"
-            ) { onEvent(BookDetailFabEvent.NavigateToMindmap) },
-            MiniFabItem(
-                R.drawable.ic_alarm_filled,
-                "독서 스톱워치 시작"
-            ) { onEvent(BookDetailFabEvent.NavigateToTimer) },
-            MiniFabItem(
-                R.drawable.ic_edit_alt_filled,
-                "독서 기록 추가"
-            ) { onEvent(BookDetailFabEvent.ShowAddManualHistoryDialog) },
+            MiniFabItem(R.drawable.ic_lightbulb_filled, "필사 추가") { onAddQuoteClick() },
+            MiniFabItem(R.drawable.ic_graph, "마인드맵 그리기") { onNavigateToMindmap() },
+            MiniFabItem(R.drawable.ic_alarm_filled, "독서 스톱워치 시작") { onNavigateToTimer() },
+            MiniFabItem(R.drawable.ic_edit_alt_filled, "독서 기록 추가") { onAddManualHistoryClick() },
         )
 
         ReadingStatus.FINISHED -> listOf(
-            MiniFabItem(
-                R.drawable.ic_lightbulb_filled,
-                "필사 추가"
-            ) { onEvent(BookDetailFabEvent.ShowAddQuoteDialog) },
-            MiniFabItem(
-                R.drawable.ic_graph,
-                "마인드맵 그리기"
-            ) { onEvent(BookDetailFabEvent.NavigateToMindmap) },
+            MiniFabItem(R.drawable.ic_lightbulb_filled, "필사 추가") { onAddQuoteClick() },
+            MiniFabItem(R.drawable.ic_graph, "마인드맵 그리기") { onNavigateToMindmap() },
         )
     }
 
@@ -198,6 +182,6 @@ data class MiniFabItem(
 @Composable
 private fun BookDetailFabPreview() {
     GureumPageTheme {
-        BookDetailFab(readingStatus = ReadingStatus.READING, onEvent = { })
+        BookDetailFab(readingStatus = ReadingStatus.READING)
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookDetailTabs.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookDetailTabs.kt
@@ -18,30 +18,30 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.History
-import com.hihihihi.domain.model.Quote
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.bookdetail.components.tabs.BookInfoTab
 import com.hihihihi.presentation.ui.bookdetail.components.tabs.QuotesTab
 import com.hihihihi.presentation.ui.bookdetail.components.tabs.ReadingRecordTab
+import com.hihihihi.presentation.ui.model.HistoryUiModel
+import com.hihihihi.presentation.ui.model.QuoteUiModel
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 import kotlinx.coroutines.launch
 
 @Composable
 fun BookDetailTabs(
-    userBook: UserBook,
-    quotes: List<Quote>,
-    histories: List<History>,
+    userBook: UserBookUiModel,
+    quotes: List<QuoteUiModel>,
+    histories: List<HistoryUiModel>,
     onQuoteEdit: (String) -> Unit,
-    onQuoteDelete: (String) -> Unit
+    onQuoteDelete: (String) -> Unit,
 ) {
     val tabTitles = listOf("독서 기록", "필사 목록", "책 정보")
     val pagerState = rememberPagerState(pageCount = { tabTitles.size })
     val scope = rememberCoroutineScope()
 
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize(),
     ) {
         HorizontalDivider(thickness = 4.dp, color = GureumTheme.colors.dividerShallow)
 
@@ -76,7 +76,7 @@ fun BookDetailTabs(
                 1 -> QuotesTab(
                     quotes = quotes,
                     onEdit = onQuoteEdit,
-                    onDelete = onQuoteDelete
+                    onDelete = onQuoteDelete,
                 )
 
                 2 -> BookInfoTab(userBook)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookSimpleInfoSection.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/BookSimpleInfoSection.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hihihihi.domain.model.ReadingStatus
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.BodyText
 import com.hihihihi.presentation.designsystem.components.BookCoverImage
@@ -32,11 +31,12 @@ import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.ui.bookdetail.mock.dummyUserBook
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 
 @Composable
 fun BookSimpleInfoSection(
-    userBook: UserBook,
-    onReadingStatusClick: () -> Unit
+    userBook: UserBookUiModel,
+    onReadingStatusClick: () -> Unit,
 ) {
     val statusColor = when (userBook.status) {
         ReadingStatus.PLANNED -> GureumTheme.colors.gray400
@@ -50,13 +50,13 @@ fun BookSimpleInfoSection(
             .padding(20.dp)
             .heightIn(max = 140.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         BookCoverImage(
             imageUrl = userBook.imageUrl,
             modifier = Modifier
                 .size(100.dp, 140.dp)
-                .clip(RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(8.dp)),
         )
         Column(
             modifier = Modifier.weight(1f),
@@ -71,12 +71,12 @@ fun BookSimpleInfoSection(
                     .fillMaxWidth()
                     .padding(vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Image(
                     painter = painterResource(id = R.drawable.ic_cloud_reading),
                     contentDescription = null,
-                    modifier = Modifier.size(40.dp)
+                    modifier = Modifier.size(40.dp),
                 )
                 Text(
                     userBook.status.displayName,
@@ -87,7 +87,7 @@ fun BookSimpleInfoSection(
                     painter = painterResource(id = R.drawable.ic_arrow_down),
                     contentDescription = null,
                     colorFilter = ColorFilter.tint(GureumTheme.colors.gray800),
-                    modifier = Modifier.clickable { onReadingStatusClick() }
+                    modifier = Modifier.clickable { onReadingStatusClick() },
                 )
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/ReadingProgressSection.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/ReadingProgressSection.kt
@@ -15,37 +15,37 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hihihihi.domain.model.ReadingStatus
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.designsystem.components.GureumLinearProgressBar
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.ui.bookdetail.mock.dummyUserBook
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 import com.hihihihi.presentation.utils.formatDateToSimpleString
 
 @Composable
 fun ReadingProgressSection(
-    userBook: UserBook
+    userBook: UserBookUiModel,
 ) {
     val start = formatDateToSimpleString(userBook.startDate)
     val end = if (userBook.status == ReadingStatus.FINISHED) formatDateToSimpleString(userBook.endDate) else ""
 
     Column(
         modifier = Modifier.padding(horizontal = 20.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Text(
             text = "독서 진행도",
             style = GureumTypography.titleMedium,
             color = GureumTheme.colors.gray800,
-            modifier = Modifier.padding(bottom = 2.dp)
+            modifier = Modifier.padding(bottom = 2.dp),
         )
         GureumLinearProgressBar(
             12,
-            userBook.currentPage.toFloat() / userBook.totalPage
+            userBook.currentPage.toFloat() / userBook.totalPage,
         )
         Row(
-            horizontalArrangement = Arrangement.SpaceBetween
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
                 text = buildAnnotatedString {

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/SetReadingStatusBottomSheet.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/SetReadingStatusBottomSheet.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.hihihihi.domain.model.ReadingStatus
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.BodySubText
 import com.hihihihi.presentation.designsystem.components.GureumButton
@@ -39,6 +38,7 @@ import com.hihihihi.presentation.designsystem.components.GureumTextField
 import com.hihihihi.presentation.designsystem.components.Medi16Text
 import com.hihihihi.presentation.designsystem.components.Semi16Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 import com.hihihihi.presentation.ui.search.component.CategoryRow
 import com.hihihihi.presentation.utils.formatMillisToLocalDateTime
 import java.time.Instant
@@ -50,7 +50,7 @@ import java.time.format.DateTimeFormatter
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SetReadingStatusBottomSheet(
-    userBook: UserBook,
+    userBook: UserBookUiModel,
     sheetState: SheetState,
     onDismiss: () -> Unit,
     onConfirm: (ReadingStatus, Int?, LocalDateTime?, LocalDateTime?) -> Unit,
@@ -82,14 +82,14 @@ fun SetReadingStatusBottomSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 20.dp)
+                .padding(horizontal = 20.dp),
         ) {
             Medi16Text("상태 변경")
             Spacer(modifier = Modifier.height(14.dp))
 
             ReadingStatusSelector(
                 selectedStatus = selectedStatus,
-                onStatusChange = { selectedStatus = it }
+                onStatusChange = { selectedStatus = it },
             )
             Spacer(modifier = Modifier.height(24.dp))
 
@@ -114,9 +114,9 @@ fun SetReadingStatusBottomSheet(
                         selectedStatus,
                         if (selectedStatus != ReadingStatus.FINISHED) pageInput.toIntOrNull() else userBook.totalPage,
                         if (selectedStatus == ReadingStatus.PLANNED) null else startDate,
-                        if (selectedStatus == ReadingStatus.FINISHED) endDate else null
+                        if (selectedStatus == ReadingStatus.FINISHED) endDate else null,
                     )
-                }
+                },
             )
             Spacer(modifier = Modifier.height(26.dp))
         }
@@ -133,31 +133,33 @@ fun SetReadingStatusBottomSheet(
                         .toLocalDate()
                     return !selectedDate.isAfter(today)
                 }
-            }
+            },
         )
 
         DatePickerDialog(
             onDismissRequest = { showStartDatePicker = false },
             confirmButton = {
-                TextButton(onClick = {
-                    showStartDatePicker = false
-                    startDatePickerState.selectedDateMillis?.let { millis ->
-                        val selectedDateTime = Instant.ofEpochMilli(millis)
-                            .atZone(ZoneId.systemDefault())
-                            .toLocalDate()
-                            .atStartOfDay()
-                        startDate = selectedDateTime
+                TextButton(
+                    onClick = {
+                        showStartDatePicker = false
+                        startDatePickerState.selectedDateMillis?.let { millis ->
+                            val selectedDateTime = Instant.ofEpochMilli(millis)
+                                .atZone(ZoneId.systemDefault())
+                                .toLocalDate()
+                                .atStartOfDay()
+                            startDate = selectedDateTime
 
-                        // 종료일이 시작일보다 이전이면 종료일 초기화
-                        if (endDate != null && selectedDateTime.isAfter(endDate)) {
-                            endDate = null
+                            // 종료일이 시작일보다 이전이면 종료일 초기화
+                            if (endDate != null && selectedDateTime.isAfter(endDate)) {
+                                endDate = null
+                            }
                         }
-                    }
-                }) { Text("확인") }
+                    },
+                ) { Text("확인") }
             },
             dismissButton = {
                 TextButton(onClick = { showStartDatePicker = false }) { Text("취소") }
-            }
+            },
         ) {
             DatePicker(state = startDatePickerState)
         }
@@ -182,23 +184,25 @@ fun SetReadingStatusBottomSheet(
 
                     return true
                 }
-            }
+            },
         )
 
         DatePickerDialog(
             onDismissRequest = { showEndDatePicker = false },
             confirmButton = {
-                TextButton(onClick = {
-                    showEndDatePicker = false
-                    endDatePickerState.selectedDateMillis?.let { millis ->
-                        val selectedDateTime = formatMillisToLocalDateTime(millis)
-                        endDate = selectedDateTime
-                    }
-                }) { Text("확인") }
+                TextButton(
+                    onClick = {
+                        showEndDatePicker = false
+                        endDatePickerState.selectedDateMillis?.let { millis ->
+                            val selectedDateTime = formatMillisToLocalDateTime(millis)
+                            endDate = selectedDateTime
+                        }
+                    },
+                ) { Text("확인") }
             },
             dismissButton = {
                 TextButton(onClick = { showEndDatePicker = false }) { Text("취소") }
-            }
+            },
         ) {
             DatePicker(state = endDatePickerState)
         }
@@ -208,7 +212,7 @@ fun SetReadingStatusBottomSheet(
 @Composable
 fun ReadingStatusSelector(
     selectedStatus: ReadingStatus,
-    onStatusChange: (ReadingStatus) -> Unit
+    onStatusChange: (ReadingStatus) -> Unit,
 ) {
     val statuses = listOf(
         ReadingStatus.PLANNED to ("읽을 예정인 책"),
@@ -217,7 +221,7 @@ fun ReadingStatusSelector(
     )
 
     Column(
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         statuses.forEach { (status, subtitle) ->
             val isSelected = selectedStatus == status
@@ -225,7 +229,7 @@ fun ReadingStatusSelector(
                 title = status.displayName,
                 subtitle = subtitle,
                 isSelected = isSelected,
-                onClick = { onStatusChange(status) }
+                onClick = { onStatusChange(status) },
             )
         }
     }
@@ -252,7 +256,7 @@ fun ReadingStatusInputs(
             GureumClickEventTextField(
                 value = startDate?.format(formatter) ?: "",
                 hint = "시작한 날",
-                onClick = onStartDateClick
+                onClick = onStartDateClick,
             )
             Spacer(Modifier.height(14.dp))
             Semi16Text("현재 페이지 (선택사항)")
@@ -265,18 +269,18 @@ fun ReadingStatusInputs(
                             .toIntOrNull()
                             ?.coerceAtMost(lastPage)
                             ?.toString()
-                            ?: ""
+                            ?: "",
                     )
                 },
                 hint = "예 : 157",
                 trailingIcon = {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_book_outline),
-                        contentDescription = "페이지"
+                        contentDescription = "페이지",
                     )
                 },
                 keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.Done
+                imeAction = ImeAction.Done,
             )
             BodySubText("시작할 페이지를 입력하세요 (기본값: 0페이지)")
         }
@@ -288,12 +292,12 @@ fun ReadingStatusInputs(
                 GureumClickEventTextField(
                     value = startDate?.format(formatter) ?: "",
                     hint = "시작한 날",
-                    onClick = onStartDateClick
+                    onClick = onStartDateClick,
                 )
                 GureumClickEventTextField(
                     value = endDate?.format(formatter) ?: "",
                     hint = "다 읽은 날",
-                    onClick = onEndDateClick
+                    onClick = onEndDateClick,
                 )
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/BookInfoTab.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/BookInfoTab.kt
@@ -9,16 +9,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.designsystem.components.GureumGenreChip
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.ui.bookdetail.mock.dummyUserBook
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 
 @Composable
 fun BookInfoTab(
-    userBook: UserBook
+    userBook: UserBookUiModel,
 ) {
     Column(
         modifier = Modifier

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/QuotesTab.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/QuotesTab.kt
@@ -76,7 +76,7 @@ fun QuotesTab(
                 key(quote.id) {
                     QuoteCard(
                         id = quote.id,
-                        date = quote.createdAt?.toLocalDate().toString(),
+                        date = quote.createdAt?.toLocalDate()?.toString() ?: "",
                         page = quote.pageNumber,
                         quote = quote.content,
                         expanded = remember { mutableStateOf(false) },

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/QuotesTab.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/QuotesTab.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -72,15 +73,17 @@ fun QuotesTab(
                 .padding(bottom = 20.dp),
         ) {
             quotes.forEach { quote ->
-                QuoteCard(
-                    id = quote.id,
-                    date = quote.createdAt?.toLocalDate().toString(),
-                    page = quote.pageNumber,
-                    quote = quote.content,
-                    expanded = remember { mutableStateOf(false) },
-                    onEdit = onEdit,
-                    onDelete = onDelete,
-                )
+                key(quote.id) {
+                    QuoteCard(
+                        id = quote.id,
+                        date = quote.createdAt?.toLocalDate().toString(),
+                        page = quote.pageNumber,
+                        quote = quote.content,
+                        expanded = remember { mutableStateOf(false) },
+                        onEdit = onEdit,
+                        onDelete = onDelete,
+                    )
+                }
             }
         }
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/QuotesTab.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/QuotesTab.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.GureumCard
 import com.hihihihi.presentation.designsystem.components.Medi14Text
@@ -36,12 +35,13 @@ import com.hihihihi.presentation.designsystem.components.Semi16Text
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
+import com.hihihihi.presentation.ui.model.QuoteUiModel
 
 @Composable
 fun QuotesTab(
-    quotes: List<Quote>,
+    quotes: List<QuoteUiModel>,
     onEdit: (quoteId: String) -> Unit,
-    onDelete: (quoteId: String) -> Unit
+    onDelete: (quoteId: String) -> Unit,
 ) {
 
     if (quotes.isEmpty()) {
@@ -50,7 +50,7 @@ fun QuotesTab(
                 .fillMaxSize()
                 .padding(horizontal = 16.dp, vertical = 100.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
             Semi16Text(
                 "아직 등록한 필사가 없어요.",
@@ -61,7 +61,7 @@ fun QuotesTab(
                 "필사 추가를 통해\n마음에 드는 문장을 남겨보세요!",
                 color = GureumTheme.colors.gray400,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     } else {
@@ -69,7 +69,7 @@ fun QuotesTab(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
-                .padding(bottom = 20.dp)
+                .padding(bottom = 20.dp),
         ) {
             quotes.forEach { quote ->
                 QuoteCard(
@@ -79,7 +79,7 @@ fun QuotesTab(
                     quote = quote.content,
                     expanded = remember { mutableStateOf(false) },
                     onEdit = onEdit,
-                    onDelete = onDelete
+                    onDelete = onDelete,
                 )
             }
         }
@@ -98,18 +98,18 @@ private fun QuoteCard(
     onDelete: (quoteId: String) -> Unit,
 ) {
     GureumCard(
-        modifier = Modifier.padding(top = 20.dp)
+        modifier = Modifier.padding(top = 20.dp),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, bottom = 14.dp, top = 8.dp)
+                .padding(start = 16.dp, bottom = 14.dp, top = 8.dp),
         ) {
             Row(
                 modifier = Modifier
                     .padding(end = 10.dp)
                     .padding(bottom = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
                     text = date,
@@ -131,25 +131,25 @@ private fun QuoteCard(
                 Box(modifier = Modifier.wrapContentSize()) {
                     IconButton(
                         onClick = { expanded.value = true },
-                        modifier = Modifier.size(32.dp)
+                        modifier = Modifier.size(32.dp),
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.ic_horizontal_ellipsis_outline),
                             contentDescription = "dot_menu",
-                            tint = GureumTheme.colors.gray600
+                            tint = GureumTheme.colors.gray600,
                         )
                     }
                     DropdownMenu(
                         expanded = expanded.value,
-                        onDismissRequest = { expanded.value = false }
+                        onDismissRequest = { expanded.value = false },
                     ) {
                         DropdownMenuItem(
                             text = { Text("수정") },
-                            onClick = { expanded.value = false; onEdit(id) }
+                            onClick = { expanded.value = false; onEdit(id) },
                         )
                         DropdownMenuItem(
                             text = { Text("삭제") },
-                            onClick = { expanded.value = false; onDelete(id) }
+                            onClick = { expanded.value = false; onDelete(id) },
                         )
                     }
                 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/ReadingRecordTab.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/components/tabs/ReadingRecordTab.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.History
 import com.hihihihi.domain.model.RecordType
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.GureumCard
@@ -29,43 +28,44 @@ import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.ui.bookdetail.mock.dummyRecords
+import com.hihihihi.presentation.ui.model.HistoryUiModel
 import com.hihihihi.presentation.utils.formatDateToSimpleString
 import com.hihihihi.presentation.utils.formatSecondsToReadableTime
 import com.hihihihi.presentation.utils.formatTimeRange
 
 @Composable
-fun ReadingRecordTab(histories: List<History>) {
+fun ReadingRecordTab(histories: List<HistoryUiModel>) {
     if (histories.isEmpty()) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 16.dp, vertical = 100.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
             Semi16Text(
                 "아직 독서 기록이 없어요.",
-                color = GureumTheme.colors.gray500
+                color = GureumTheme.colors.gray500,
             )
             Spacer(Modifier.height(16.dp))
             Medi14Text(
                 "독서 스톱워치로 독서를 시작하거나\n놓친 기록을 직접 추가해보세요!",
                 color = GureumTheme.colors.gray400,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     } else {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 12.dp)
+                .padding(bottom = 12.dp),
         ) {
             histories
                 .filter { it.date != null }
                 .sortedByDescending { it.date }
                 .groupBy { it.date!!.toLocalDate() }
-                .forEach { (localDate, dailyRecords) ->
+                .forEach { (_, dailyRecords) ->
                     Row(
                         modifier = Modifier
                             .padding(horizontal = 24.dp)
@@ -76,76 +76,25 @@ fun ReadingRecordTab(histories: List<History>) {
                             text = formatDateToSimpleString(dailyRecords.first().date),
                             modifier = Modifier,
                             color = GureumTheme.colors.gray400,
-                            style = GureumTypography.bodySmall
+                            style = GureumTypography.bodySmall,
                         )
                         Spacer(modifier = Modifier.weight(1f))
                         Semi16Text(
                             text = formatSecondsToReadableTime(
-                                dailyRecords.sumOf { it.readTime }
+                                dailyRecords.sumOf { it.readTime },
                             ),
-                            isUnderline = true
+                            isUnderline = true,
                         )
                     }
                     dailyRecords.forEach { record ->
                         RecordCard(
                             isTimer = record.recordType == RecordType.TIMER,
-                            id = record.id,
                             timeRange = formatTimeRange(record.startTime, record.endTime),
-                            duration = formatSecondsToReadableTime(record.readTime)
+                            duration = formatSecondsToReadableTime(record.readTime),
                         )
                     }
                 }
         }
-    }
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(bottom = 12.dp)
-    ) {
-        histories
-            .filter { it.date != null }
-            .sortedByDescending { it.date }
-            .groupBy { it.date!!.toLocalDate() }
-            .forEach { (localDate, dailyRecords) ->
-                Row(
-                    modifier = Modifier
-                        .padding(horizontal = 24.dp)
-                        .padding(top = 24.dp),
-                    verticalAlignment = Alignment.Bottom,
-                ) {
-                    Text(
-                        text = formatDateToSimpleString(dailyRecords.first().date),
-                        modifier = Modifier,
-                        color = GureumTheme.colors.gray400,
-                        style = GureumTypography.bodySmall
-                    )
-                    Spacer(modifier = Modifier.weight(1f))
-
-
-                    Semi16Text(
-                        text = formatSecondsToReadableTime(
-                            dailyRecords.sumOf { it.readTime }
-                        ),
-                        isUnderline = true
-                    )
-
-//                    TitleText(
-//                        text = formatSecondsToReadableTime(
-//                            dailyRecords.sumOf { it.readTime }
-//                        ),
-//                        isUnderline = true
-//                    )
-
-                }
-                dailyRecords.forEach { record ->
-                    RecordCard(
-                        isTimer = record.recordType == RecordType.TIMER,
-                        id = record.id,
-                        timeRange = formatTimeRange(record.startTime, record.endTime),
-                        duration = formatSecondsToReadableTime(record.readTime)
-                    )
-                }
-            }
     }
 }
 
@@ -153,9 +102,8 @@ fun ReadingRecordTab(histories: List<History>) {
 private fun RecordCard(
     modifier: Modifier = Modifier,
     isTimer: Boolean = true,
-    id: String,
     timeRange: String,
-    duration: String
+    duration: String,
 ) {
     GureumCard(
         modifier = modifier
@@ -171,17 +119,17 @@ private fun RecordCard(
             Icon(
                 painter = painterResource(
                     if (isTimer) R.drawable.ic_alarm_filled
-                    else R.drawable.ic_edit_filled
+                    else R.drawable.ic_edit_filled,
                 ),
                 contentDescription = "기록 형태",
-                tint = GureumTheme.colors.gray300
+                tint = GureumTheme.colors.gray300,
             )
             Spacer(modifier = Modifier.width(6.dp))
 
             Text(
                 text = timeRange,
                 style = GureumTypography.titleMedium,
-                color = GureumTheme.colors.gray600
+                color = GureumTheme.colors.gray600,
             )
             Spacer(modifier = Modifier.weight(1f))
             Semi16Text(duration, color = GureumTheme.colors.gray800)
@@ -204,10 +152,9 @@ private fun ReadingRecordTabPreview() {
 private fun RecordCardPreview() {
     GureumPageTheme {
         RecordCard(
-            id = "0",
             isTimer = false,
             timeRange = "15:00 ~ 15:10",
-            duration = "9분 30초"
+            duration = "9분 30초",
         )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/mock/Mock.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/bookdetail/mock/Mock.kt
@@ -1,67 +1,55 @@
 package com.hihihihi.presentation.ui.bookdetail.mock
 
-import com.hihihihi.domain.model.History
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.domain.model.ReadingStatus
 import com.hihihihi.domain.model.RecordType
-import com.hihihihi.domain.model.UserBook
+import com.hihihihi.presentation.ui.model.HistoryUiModel
+import com.hihihihi.presentation.ui.model.QuoteUiModel
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 import java.time.LocalDateTime
 
 val now = LocalDateTime.now()
+
 val dummyRecords = listOf(
-    History(
-        id = "1",
-        userId = "user1",
-        userBookId = "book1",
+    HistoryUiModel(
+        readTime = 19 * 60 + 30,
+        readPageCount = 10,
         date = now,
         startTime = now.minusMinutes(20),
         endTime = now,
-        readTime = 19 * 60 + 30,
-        readPageCount = 10,
-        recordType = RecordType.TIMER
+        recordType = RecordType.TIMER,
     ),
-    History(
-        id = "2",
-        userId = "user1",
-        userBookId = "book1",
+    HistoryUiModel(
+        readTime = 5 * 60,
+        readPageCount = 3,
         date = now,
         startTime = now.minusMinutes(10),
         endTime = now,
-        readTime = 5 * 60,
-        readPageCount = 3,
-        recordType = RecordType.MANUAL
+        recordType = RecordType.MANUAL,
     ),
-    History(
-        id = "3",
-        userId = "user1",
-        userBookId = "book1",
+    HistoryUiModel(
+        readTime = 15 * 60,
+        readPageCount = 8,
         date = now.minusDays(1),
         startTime = now.minusDays(1).minusMinutes(30),
         endTime = now.minusDays(1),
-        readTime = 15 * 60,
-        readPageCount = 8,
-        recordType = RecordType.TIMER
-    )
+        recordType = RecordType.TIMER,
+    ),
 )
 
 val dummyQuotes = listOf(
-    Quote(
+    QuoteUiModel(
         id = "1",
-        userId = "user1",
-        userBookId = "book1",
-        content = "네가 4시에 온다면 난 3시부터 행복할거야. 네가 4시에 온다면 난 3시부터 행복할거야.네가 4시에 온다면 난 3시부터 행복할거야.네가 4시에 온다면 난 3시부터 행복할거야.네가 4시에 온다면 난 3시부터 행복할거야.네가 4시에 온다면 난 3시부터 행복할거야.네가 4시에 온다면 난 3시부터 행복할거야.네가 4시에 온다면 난 3시부터 행복할거야.네가 4시에 온다면 난 3시부터 행복할거야.",
+        content = "네가 4시에 온다면 난 3시부터 행복할거야. 네가 4시에 온다면 난 3시부터 행복할거야.",
         pageNumber = 120,
         isLiked = false,
         createdAt = LocalDateTime.of(2025, 7, 29, 10, 0),
         title = "어린 왕자",
         author = "생텍쥐페리",
         publisher = "출판사A",
-        imageUrl = ""
+        imageUrl = "",
     ),
-    Quote(
+    QuoteUiModel(
         id = "2",
-        userId = "user1",
-        userBookId = "book1",
         content = "사막이 아름다운 건 어딘가에 샘을 감추고 있기 때문이야.",
         pageNumber = null,
         isLiked = true,
@@ -69,27 +57,25 @@ val dummyQuotes = listOf(
         title = "어린 왕자",
         author = "생텍쥐페리",
         publisher = "출판사A",
-        imageUrl = ""
-    )
+        imageUrl = "",
+    ),
 )
 
-val dummyUserBook = UserBook(
+val dummyUserBook = UserBookUiModel(
     userBookId = "dummyId123",
-    userId = "userId456",
-    isbn10 = "1234567890",
-    isbn13 = "9781234567897",
     title = "더미 책 제목",
     author = "더미 작가",
     imageUrl = "https://dummyimage.com/200x300/cccccc/000000&text=Book+Cover",
-    isLiked = true,
+    status = ReadingStatus.READING,
     totalPage = 350,
     currentPage = 120,
     startDate = LocalDateTime.of(2023, 1, 10, 0, 0),
     endDate = null,
-    totalReadTime = 3600, // 초 단위
-    status = ReadingStatus.READING,
+    totalReadTime = 3600,
     review = "아직 읽는 중이지만 흥미로워요.",
     rating = 4.5,
     category = "소설",
-    createdAt = LocalDateTime.now()
+    publisher = null,
+    isbn13 = "9781234567897",
+    description = null,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeScreen.kt
@@ -6,18 +6,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.domain.model.Quote
 import com.hihihihi.domain.model.User
 import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
-import com.hihihihi.presentation.navigation.NavigationRoute
 import com.hihihihi.presentation.ui.home.components.CurrentReadingBookSection
 import com.hihihihi.presentation.ui.home.components.ErrorView
 import com.hihihihi.presentation.ui.home.components.LoadingView
@@ -30,26 +28,23 @@ import com.hihihihi.presentation.ui.home.mock.mockUserBooks
 
 @Composable
 fun HomeScreen(
-    // Hilt로 ViewModel을 주입받음. DI를 통해 뷰모델의 생명주기를 컴포즈에 맞게 관리
-    navController: NavHostController,
+    onNavigateToBookDetail: (String) -> Unit,
+    onNavigateToSearch: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
-    // viewModel에서 선언한 uiState Flow를 Compose에서 관찰 (State로 변환).
-    // 상태가 변경되면 recomposition 발생
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 
-    // ui
     when {
         uiState.value.isLoading -> {
-            LoadingView() // 데이터 로딩 중일 때 표시될 뷰. 분리된 Composable 사용
+            LoadingView()
         }
 
         uiState.value.errorMessage != null -> {
-            ErrorView(message = "홈 화면 데이터를 가져오는데 실패했어요") // 에러 발생 시 표시될 뷰
+            ErrorView(message = "홈 화면 데이터를 가져오는데 실패했어요")
         }
 
         uiState.value.homeData != null -> {
-            val homeData = uiState.value.homeData!! // null 아님 확정
+            val homeData = uiState.value.homeData!!
 
             Column {
                 HomeScreenContent(
@@ -58,15 +53,9 @@ fun HomeScreen(
                     quotes = homeData.quotes,
                     todayReadTime = homeData.todayReadTime,
                     dailyGoalTime = homeData.user.dailyGoalTime,
-                    onBookClick = {
-                        navController.navigate(NavigationRoute.BookDetail.createRoute(it))
-                    },
-                    onSearchBarClick = {
-                        navController.navigate(NavigationRoute.Search.route)
-                    },
-                    onChangeDailyGoalTime = {
-                        viewModel.changeDailyGoalTime(it)
-                    }
+                    onBookClick = onNavigateToBookDetail,
+                    onSearchBarClick = onNavigateToSearch,
+                    onChangeDailyGoalTime = { viewModel.changeDailyGoalTime(it) }
                 )
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
@@ -36,7 +36,7 @@ fun HomeScreen(
 ) {
     // viewModel에서 선언한 uiState Flow를 Compose에서 관찰 (State로 변환).
     // 상태가 변경되면 recomposition 발생
-    val uiState = viewModel.uiState.collectAsState()
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 
     // ui
     when {

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeScreen.kt
@@ -12,9 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.hihihihi.domain.model.Quote
-import com.hihihihi.domain.model.User
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.ui.home.components.CurrentReadingBookSection
 import com.hihihihi.presentation.ui.home.components.ErrorView
@@ -22,9 +19,8 @@ import com.hihihihi.presentation.ui.home.components.LoadingView
 import com.hihihihi.presentation.ui.home.components.RandomQuoteSection
 import com.hihihihi.presentation.ui.home.components.ReadingGoalSection
 import com.hihihihi.presentation.ui.home.components.SearchBarWithBackground
-import com.hihihihi.presentation.ui.home.mock.dummyQuotes
-import com.hihihihi.presentation.ui.home.mock.mockUser
-import com.hihihihi.presentation.ui.home.mock.mockUserBooks
+import com.hihihihi.presentation.ui.home.mock.mockHomeUiModel
+import com.hihihihi.presentation.ui.model.HomeUiModel
 
 @Composable
 fun HomeScreen(
@@ -32,30 +28,18 @@ fun HomeScreen(
     onNavigateToSearch: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
-    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     when {
-        uiState.value.isLoading -> {
-            LoadingView()
-        }
-
-        uiState.value.errorMessage != null -> {
-            ErrorView(message = "홈 화면 데이터를 가져오는데 실패했어요")
-        }
-
-        uiState.value.homeData != null -> {
-            val homeData = uiState.value.homeData!!
-
+        uiState.isLoading -> LoadingView()
+        uiState.errorMessage != null -> ErrorView(message = "홈 화면 데이터를 가져오는데 실패했어요")
+        uiState.homeUiModel != null -> {
             Column {
                 HomeScreenContent(
-                    user = homeData.user,
-                    books = homeData.userBooks,
-                    quotes = homeData.quotes,
-                    todayReadTime = homeData.todayReadTime,
-                    dailyGoalTime = homeData.user.dailyGoalTime,
+                    homeUiModel = uiState.homeUiModel!!,
                     onBookClick = onNavigateToBookDetail,
                     onSearchBarClick = onNavigateToSearch,
-                    onChangeDailyGoalTime = { viewModel.changeDailyGoalTime(it) }
+                    onChangeDailyGoalTime = { viewModel.changeDailyGoalTime(it) },
                 )
             }
         }
@@ -64,52 +48,41 @@ fun HomeScreen(
 
 @Composable
 fun HomeScreenContent(
-    user: User,
-    books: List<UserBook>,
-    quotes: List<Quote>,
-    todayReadTime: Int,
-    dailyGoalTime: Int,
+    homeUiModel: HomeUiModel,
     onBookClick: (String) -> Unit,
     onChangeDailyGoalTime: (Int) -> Unit,
-    onSearchBarClick: () -> Unit
+    onSearchBarClick: () -> Unit,
 ) {
     val scrollState = rememberLazyListState()
-
-    val goalSeconds by rememberUpdatedState(newValue = dailyGoalTime)
-    val totalReadSeconds by rememberUpdatedState(newValue = todayReadTime)
-
+    val goalSeconds by rememberUpdatedState(newValue = homeUiModel.dailyGoalTime)
+    val totalReadSeconds by rememberUpdatedState(newValue = homeUiModel.todayReadTime)
 
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
         state = scrollState,
     ) {
         item {
             SearchBarWithBackground(
-                user = user,
-                onSearchBarClick,
+                nickname = homeUiModel.nickname,
+                appellation = homeUiModel.appellation,
+                onSearchBarClick = onSearchBarClick,
             )
         }
-
         item {
             CurrentReadingBookSection(
-                books = books,
+                books = homeUiModel.userBooks,
                 onBookClick = { onBookClick(it) },
-                onAddBookClick = onSearchBarClick
+                onAddBookClick = onSearchBarClick,
             )
         }
-
         item {
-            RandomQuoteSection(
-                quotes = quotes
-            )
+            RandomQuoteSection(quotes = homeUiModel.quotes)
         }
-
         item {
             ReadingGoalSection(
                 totalReadSeconds,
                 goalSeconds,
-                onGoalChange = onChangeDailyGoalTime
+                onGoalChange = onChangeDailyGoalTime,
             )
         }
     }
@@ -120,7 +93,6 @@ fun HomeScreenContent(
 @Composable
 private fun HomePreview() {
     GureumPageTheme {
-        HomeScreenContent(mockUser, mockUserBooks, dummyQuotes, 200, 300, onBookClick = {}, {}, {})
+        HomeScreenContent(mockHomeUiModel, onBookClick = {}, {}, {})
     }
 }
-

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeUiState.kt
@@ -1,10 +1,9 @@
 package com.hihihihi.presentation.ui.home
 
-import com.hihihihi.domain.usecase.user.HomeData
+import com.hihihihi.presentation.ui.model.HomeUiModel
 
-// 홈 화면의 UI 상태를 나타내는 데이터 클래스
 data class HomeUiState(
-    val isLoading: Boolean = false, // 데이터 로딩 중인지
-    val homeData: HomeData? = null, // 홈 화면에 표시할 데이터
-    val errorMessage: String? = null, // 에러 메세지 (null이면 에러 없음)
+    val isLoading: Boolean = false,
+    val homeUiModel: HomeUiModel? = null,
+    val errorMessage: String? = null,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.hihihihi.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.hihihihi.domain.usecase.user.GetHomeDataUseCase
 import com.hihihihi.domain.usecase.user.UpdateDailyGoalTimeUseCase
+import com.hihihihi.presentation.ui.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,16 +18,14 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val getHomeDataUseCase: GetHomeDataUseCase,
     private val changeDailyGoalTimeUseCase: UpdateDailyGoalTimeUseCase,
-    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
 ) : ViewModel() {
+
     private val currentUid: String?
         get() = getCurrentUserIdUseCase()
 
-
-    // UI 상태를 관리하는 StateFlow (내부 업데이트는 _uiState, 외부에선 uiState만 노출)
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState
-
 
     init {
         viewModelScope.launch {
@@ -39,7 +38,7 @@ class HomeViewModel @Inject constructor(
                     }
                     .collect { homeData ->
                         _uiState.update {
-                            it.copy(homeData = homeData, isLoading = false)
+                            it.copy(homeUiModel = homeData.toUiModel(), isLoading = false)
                         }
                     }
             }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/components/CurrentReadingBookSection.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/components/CurrentReadingBookSection.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -29,7 +30,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.hihihihi.presentation.R
@@ -152,16 +152,12 @@ private fun ReadingBooksPager(
 @Composable
 private fun ReadingBookCard(
     book: UserBookUiModel,
-    pagerState: androidx.compose.foundation.pager.PagerState,
+    pagerState: PagerState,
     page: Int,
     scaleSizeRatio: Float,
     onBookClick: (String) -> Unit,
 ) {
     BoxWithConstraints {
-        val maxWidthDp = pxToDp(constraints.maxWidth)
-        val bookmarkWidth = 24.dp // 북마크 아이콘 너비 + 여백
-        val availableTextWidth = maxWidthDp - bookmarkWidth - 32.dp // 패딩 고려
-
         GureumCard(
             modifier = Modifier
                 .graphicsLayer {
@@ -185,13 +181,11 @@ private fun ReadingBookCard(
                 },
             onClick = { onBookClick(book.userBookId) },
         ) {
-            BookCardContent(
-                book = book,
-                availableTextWidth = availableTextWidth,
-            )
+            BookCardContent(book = book)
         }
 
         // 북마크 아이콘
+        val maxWidthDp = pxToDp(constraints.maxWidth)
         Icon(
             painter = painterResource(R.drawable.ic_bookmark),
             contentDescription = "북마크",
@@ -206,7 +200,6 @@ private fun ReadingBookCard(
 @Composable
 private fun BookCardContent(
     book: UserBookUiModel,
-    availableTextWidth: Dp,
 ) {
     Column(modifier = Modifier.padding(16.dp)) {
         Row(modifier = Modifier.fillMaxWidth()) {

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/components/CurrentReadingBookSection.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/components/CurrentReadingBookSection.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.BookCoverImage
 import com.hihihihi.presentation.designsystem.components.GureumCard
@@ -41,6 +40,7 @@ import com.hihihihi.presentation.designsystem.components.Medi14Text
 import com.hihihihi.presentation.designsystem.components.Semi16Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 import com.hihihihi.presentation.utils.formatDateToSimpleString
 import com.hihihihi.presentation.utils.formatSecondsToReadableTime
 import com.hihihihi.presentation.utils.pxToDp
@@ -49,9 +49,9 @@ import kotlin.math.absoluteValue
 @SuppressLint("RestrictedApi", "UnusedBoxWithConstraintsScope")
 @Composable
 fun CurrentReadingBookSection(
-    books: List<UserBook>,
+    books: List<UserBookUiModel>,
     onBookClick: (String) -> Unit,
-    onAddBookClick: () -> Unit
+    onAddBookClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -61,7 +61,7 @@ fun CurrentReadingBookSection(
         Box(
             modifier = Modifier
                 .padding(horizontal = 20.dp)
-                .padding(top = 8.dp)
+                .padding(top = 8.dp),
         ) {
             Semi16Text("독서중인 책", isUnderline = true)
         }
@@ -73,7 +73,7 @@ fun CurrentReadingBookSection(
         } else {
             ReadingBooksPager(
                 books = books,
-                onBookClick = onBookClick
+                onBookClick = onBookClick,
             )
         }
 
@@ -86,26 +86,26 @@ fun CurrentReadingBookSection(
 
 @Composable
 fun EmptyReadingBooksCard(
-    onAddBookClick: () -> Unit
+    onAddBookClick: () -> Unit,
 ) {
     GureumCard(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp, vertical = 12.dp),
-        onClick = onAddBookClick
+        onClick = onAddBookClick,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 32.dp),
             verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(
                 painter = painterResource(R.drawable.ic_plus),
                 contentDescription = "책 추가",
                 tint = GureumTheme.colors.gray300,
-                modifier = Modifier.size(32.dp)
+                modifier = Modifier.size(32.dp),
             )
 
             Spacer(Modifier.height(20.dp))
@@ -119,8 +119,8 @@ fun EmptyReadingBooksCard(
 
 @Composable
 private fun ReadingBooksPager(
-    books: List<UserBook>,
-    onBookClick: (String) -> Unit
+    books: List<UserBookUiModel>,
+    onBookClick: (String) -> Unit,
 ) {
     val pagerState = rememberPagerState(pageCount = { books.size })
     val contentPadding = 30.dp
@@ -142,7 +142,7 @@ private fun ReadingBooksPager(
             pagerState = pagerState,
             page = page,
             scaleSizeRatio = scaleSizeRatio,
-            onBookClick = onBookClick
+            onBookClick = onBookClick,
         )
     }
 }
@@ -151,11 +151,11 @@ private fun ReadingBooksPager(
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 private fun ReadingBookCard(
-    book: UserBook,
+    book: UserBookUiModel,
     pagerState: androidx.compose.foundation.pager.PagerState,
     page: Int,
     scaleSizeRatio: Float,
-    onBookClick: (String) -> Unit
+    onBookClick: (String) -> Unit,
 ) {
     BoxWithConstraints {
         val maxWidthDp = pxToDp(constraints.maxWidth)
@@ -183,11 +183,11 @@ private fun ReadingBookCard(
                         translationX = sign * size.width * (1 - it) / 2
                     }
                 },
-            onClick = { onBookClick(book.userBookId) }
+            onClick = { onBookClick(book.userBookId) },
         ) {
             BookCardContent(
                 book = book,
-                availableTextWidth = availableTextWidth
+                availableTextWidth = availableTextWidth,
             )
         }
 
@@ -198,15 +198,15 @@ private fun ReadingBookCard(
             tint = GureumTheme.colors.primary,
             modifier = Modifier
                 .offset(x = maxWidthDp * 0.88f, y = 0.dp)
-                .height(24.dp)
+                .height(24.dp),
         )
     }
 }
 
 @Composable
 private fun BookCardContent(
-    book: UserBook,
-    availableTextWidth: Dp
+    book: UserBookUiModel,
+    availableTextWidth: Dp,
 ) {
     Column(modifier = Modifier.padding(16.dp)) {
         Row(modifier = Modifier.fillMaxWidth()) {
@@ -225,7 +225,7 @@ private fun BookCardContent(
             BookInfo(
                 book = book,
                 modifier = Modifier
-                    .weight(1f)
+                    .weight(1f),
             )
         }
 
@@ -238,12 +238,12 @@ private fun BookCardContent(
 
 @Composable
 private fun BookInfo(
-    book: UserBook,
-    modifier: Modifier = Modifier
+    book: UserBookUiModel,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.SpaceBetween
+        verticalArrangement = Arrangement.SpaceBetween,
     ) {
         Column {
             // 제목 - 북마크 공간 고려해서 maxLines 조정
@@ -253,7 +253,7 @@ private fun BookInfo(
                 color = GureumTheme.colors.primary,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth(0.85f) // 북마크 공간 확보
+                modifier = Modifier.fillMaxWidth(0.85f), // 북마크 공간 확보
             )
 
             Spacer(Modifier.height(4.dp))
@@ -263,7 +263,7 @@ private fun BookInfo(
                 style = GureumTypography.bodySmall,
                 color = GureumTheme.colors.gray500,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
 
             Spacer(Modifier.height(4.dp))
@@ -271,17 +271,17 @@ private fun BookInfo(
             Text(
                 text = "누적 독서 시간: ${formatSecondsToReadableTime(book.totalReadTime)}",
                 style = GureumTypography.bodySmall,
-                color = GureumTheme.colors.gray500
+                color = GureumTheme.colors.gray500,
             )
         }
     }
 }
 
 @Composable
-private fun BookProgress(book: UserBook) {
+private fun BookProgress(book: UserBookUiModel) {
     Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.End
+        horizontalAlignment = Alignment.End,
     ) {
         val progress = if (book.totalPage > 0) {
             book.currentPage.toFloat() / book.totalPage
@@ -289,7 +289,7 @@ private fun BookProgress(book: UserBook) {
 
         GureumLinearProgressBar(
             progress = progress,
-            height = 6
+            height = 6,
         )
 
         Spacer(Modifier.height(4.dp))
@@ -297,7 +297,7 @@ private fun BookProgress(book: UserBook) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             book.startDate?.let { startDate ->
                 Text(
@@ -310,7 +310,7 @@ private fun BookProgress(book: UserBook) {
             Text(
                 text = "${book.currentPage} / ${book.totalPage}",
                 style = GureumTypography.labelSmall,
-                color = GureumTheme.colors.gray500
+                color = GureumTheme.colors.gray500,
             )
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/components/RandomQuoteSection.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/components/RandomQuoteSection.kt
@@ -36,20 +36,20 @@ import com.airbnb.lottie.compose.LottieClipSpec
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieAnimatable
 import com.airbnb.lottie.compose.rememberLottieComposition
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.presentation.designsystem.components.GureumCard
 import com.hihihihi.presentation.designsystem.components.Semi16Text
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.ui.home.mock.dummyQuotes
+import com.hihihihi.presentation.ui.model.QuoteUiModel
 import com.hihihihi.presentation.utils.formatDateToSimpleString
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 
 @Composable
 fun RandomQuoteSection(
-    quotes: List<Quote>,
+    quotes: List<QuoteUiModel>,
 ) {
     // 현재 인덱스 저장해서 다음 랜덤때 제외하도록
     var currentIndex by remember { mutableStateOf(0) }
@@ -57,7 +57,7 @@ fun RandomQuoteSection(
     Column(
         modifier = Modifier
             .background(GureumTheme.colors.background)
-            .padding(16.dp)
+            .padding(16.dp),
     ) {
         Semi16Text("필사한 문장", isUnderline = true)
         Spacer(Modifier.height(12.dp))
@@ -72,7 +72,7 @@ fun RandomQuoteSection(
                     if (quotes.size > 1) {  // 1일때는 안바뀌도록
                         currentIndex = (quotes.indices - currentIndex).random()
                     }
-                }
+                },
             )
         } else {
             // 필사 목록 비어있을 때 처리
@@ -81,7 +81,7 @@ fun RandomQuoteSection(
                 title = "구름한장",
                 date = formatDateToSimpleString(LocalDateTime.now()),
                 onClick = {
-                }
+                },
             )
         }
     }
@@ -92,12 +92,12 @@ fun QuoteCard(
     quote: String,
     title: String,
     date: String,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     Box(
         modifier = Modifier
             .wrapContentHeight()
-            .padding(bottom = 30.dp) // 구름 하단 여유 공간 확보
+            .padding(bottom = 30.dp), // 구름 하단 여유 공간 확보
         //TODO 더 나은 방식이 있지 않을까
     ) {
         // 말풍선 본체
@@ -108,7 +108,7 @@ fun QuoteCard(
                         .fillMaxWidth()
                         .padding(bottom = 8.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     // 책 제목
                     Text(
@@ -116,7 +116,7 @@ fun QuoteCard(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         style = GureumTypography.titleLarge.copy(color = GureumTheme.colors.gray900),
-                        modifier = Modifier.weight(1f) // 날짜 공간 보장용
+                        modifier = Modifier.weight(1f), // 날짜 공간 보장용
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     // 날짜
@@ -130,7 +130,7 @@ fun QuoteCard(
                     text = "\"${quote}\"",
                     style = GureumTypography.bodyMedium.copy(color = GureumTheme.colors.gray700),
                     maxLines = 4,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }
@@ -140,7 +140,7 @@ fun QuoteCard(
             modifier = Modifier
                 .size(100.dp)
                 .align(Alignment.BottomEnd)
-                .offset(x = 16.dp, y = 60.dp)
+                .offset(x = 16.dp, y = 60.dp),
         ) {
             GuruemBulbLottie(onClick)
         }
@@ -150,7 +150,7 @@ fun QuoteCard(
 
 @Composable
 fun GuruemBulbLottie(
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     val composition by rememberLottieComposition(LottieCompositionSpec.Asset("cloud_bulb.json"))
     val scope = rememberCoroutineScope()
@@ -161,7 +161,7 @@ fun GuruemBulbLottie(
         modifier = Modifier
             .clickable(
                 interactionSource = interactionSource,
-                indication = null
+                indication = null,
             ) {
                 onClick()
                 scope.launch {
@@ -172,17 +172,17 @@ fun GuruemBulbLottie(
                     animatable.animate(
                         composition = composition,
                         clipSpec = LottieClipSpec.Progress(0f, 0.9f),
-                        iterations = 1
+                        iterations = 1,
                     )
                     animatable.snapTo(progress = 0f) // 처음으로 되돌리기
                 }
-            }
+            },
     ) {
         if (composition != null) {
             LottieAnimation(
                 composition = composition,
                 progress = { animatable.progress },
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier.fillMaxSize(),
             )
         } else {
             // TODO 로티가 로딩이 좀 느려서 자리가 비어있다가 생기길래 일단 인디케이터를 넣어놨는데 어떻게 하면 좋을지🥲

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/components/SearchBarWithBackground.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/components/SearchBarWithBackground.kt
@@ -35,20 +35,19 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.User
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.Floating
 import com.hihihihi.presentation.designsystem.components.Medi12Text
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
-import com.hihihihi.presentation.ui.home.mock.mockUser
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun SearchBarWithBackground(
-    user: User,
-    onSearchBarClick: () -> Unit = {}
+    nickname: String,
+    appellation: String,
+    onSearchBarClick: () -> Unit = {},
 ) {
     val backGroundImage = if (GureumTheme.isDarkTheme) R.drawable.bg_home_dark else R.drawable.bg_home_light
 
@@ -65,14 +64,14 @@ fun SearchBarWithBackground(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(290.dp), // 배경이 겹쳐질 만큼만 높이
-            contentScale = ContentScale.Crop
+            contentScale = ContentScale.Crop,
         )
 
         Column(
             Modifier
                 .fillMaxSize()
                 .padding(20.dp)
-                .statusBarsPadding()
+                .statusBarsPadding(),
         ) {
             Box(
                 modifier = Modifier
@@ -82,21 +81,21 @@ fun SearchBarWithBackground(
                     .border(1.dp, GureumTheme.colors.textFieldOutline, shape = RoundedCornerShape(50)) // 테두리
                     .clickable(
                         indication = null,
-                        interactionSource = remember { MutableInteractionSource() }
+                        interactionSource = remember { MutableInteractionSource() },
                     ) { onSearchBarClick() }
                     .padding(horizontal = 16.dp),
-                contentAlignment = Alignment.CenterStart
+                contentAlignment = Alignment.CenterStart,
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         painter = painterResource(R.drawable.ic_search_outline),
                         contentDescription = null,
-                        tint = GureumTheme.colors.gray400
+                        tint = GureumTheme.colors.gray400,
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Medi12Text(
                         text = "책 검색",
-                        color = GureumTheme.colors.gray400
+                        color = GureumTheme.colors.gray400,
                     )
                 }
             }
@@ -108,20 +107,21 @@ fun SearchBarWithBackground(
                     text = buildAnnotatedString {
                         withStyle(
                             GureumTypography.titleLarge.toSpanStyle()
-                                .copy(color = GureumTheme.colors.primary)
-                        ) { append(user.appellation) }
+                                .copy(color = GureumTheme.colors.primary),
+                        ) { append(appellation) }
                         withStyle(
                             GureumTypography.titleLarge.toSpanStyle()
-                                .copy(color = GureumTheme.colors.gray900)
+                                .copy(color = GureumTheme.colors.gray900),
                         ) {
-                            append(" ${user.nickname}")
+                            append(" $nickname")
 
                         }
                         withStyle(
                             GureumTypography.bodyLarge.toSpanStyle()
-                                .copy(color = GureumTheme.colors.gray900)
+                                .copy(color = GureumTheme.colors.gray900),
                         ) { append(" 님") }
-                    })
+                    },
+                )
 
                 Spacer(modifier = Modifier.height(6.dp))
 
@@ -129,23 +129,23 @@ fun SearchBarWithBackground(
                     text = buildAnnotatedString {
                         withStyle(
                             GureumTypography.bodyLarge.toSpanStyle()
-                                .copy(color = GureumTheme.colors.gray900)
+                                .copy(color = GureumTheme.colors.gray900),
                         ) { append("오늘도 ") }
                         withStyle(
                             GureumTypography.titleLarge.toSpanStyle()
-                                .copy(color = GureumTheme.colors.primary)
+                                .copy(color = GureumTheme.colors.primary),
                         ) { append("구름한장") }
                         withStyle(
                             GureumTypography.bodyLarge.toSpanStyle()
-                                .copy(color = GureumTheme.colors.gray900)
+                                .copy(color = GureumTheme.colors.gray900),
                         ) { append("과 함께") }
-                    }
+                    },
                 )
 
                 // \n 으로 했더니 간격이 이상해서 별도로 뺌
                 Text(
                     text = "마음의 양식을 쌓아볼까요?",
-                    style = MaterialTheme.typography.bodyLarge.copy(color = GureumTheme.colors.gray900)
+                    style = MaterialTheme.typography.bodyLarge.copy(color = GureumTheme.colors.gray900),
                 )
 
             }
@@ -155,14 +155,14 @@ fun SearchBarWithBackground(
             modifier = Modifier
                 .offset(
                     x = maxWidth * 0.6f, // 오른쪽 비율 위치
-                    y = maxHeight * 0.25f // 아래 비율 위치
+                    y = maxHeight * 0.25f, // 아래 비율 위치
                 )
-                .statusBarsPadding()
+                .statusBarsPadding(),
         ) {
             Image(
                 painter = painterResource(id = R.drawable.ic_cloud_reading),
                 contentDescription = "Floating Cloud",
-                modifier = Modifier.size(130.dp)
+                modifier = Modifier.size(130.dp),
             )
         }
 
@@ -173,8 +173,8 @@ fun SearchBarWithBackground(
                 .align(Alignment.BottomCenter)
                 .background(
                     color = GureumTheme.colors.background,
-                    shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
-                )
+                    shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
+                ),
         )
     }
 }
@@ -185,6 +185,6 @@ fun SearchBarWithBackground(
 @Composable
 private fun HomePreview() {
     GureumPageTheme {
-        SearchBarWithBackground(mockUser)
+        SearchBarWithBackground(nickname = "구름이", appellation = "독서왕")
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/home/mock/Mock.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/home/mock/Mock.kt
@@ -1,53 +1,53 @@
 package com.hihihihi.presentation.ui.home.mock
 
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.domain.model.ReadingStatus
-import com.hihihihi.domain.model.User
-import com.hihihihi.domain.model.UserBook
+import com.hihihihi.presentation.ui.model.HomeUiModel
+import com.hihihihi.presentation.ui.model.QuoteUiModel
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 import java.time.LocalDateTime
 
-val mockUser = User("", "히히히히", "새벽독서가", 0, "", LocalDateTime.now())
-
 val mockUserBooks = listOf(
-    UserBook(
+    UserBookUiModel(
         userBookId = "ub001",
-        userId = "user123",
         title = "죄와 벌",
         author = "표도르 도스토예프스키",
         imageUrl = "https://minumsa.minumsa.com/wp-content/uploads/bookcover/284-죄와벌1_표1-500x851.jpg",
+        status = ReadingStatus.READING,
         totalPage = 525,
         currentPage = 170,
         startDate = LocalDateTime.of(2025, 7, 29, 8, 0),
         endDate = null,
-        totalReadTime = 5213, // 분 단위
-        status = ReadingStatus.READING,
+        totalReadTime = 5213,
         review = null,
         rating = null,
-        createdAt = LocalDateTime.of(2025, 7, 29, 7, 30)
+        category = null,
+        publisher = null,
+        isbn13 = null,
+        description = null,
     ),
-    UserBook(
+    UserBookUiModel(
         userBookId = "ub002",
-        userId = "user123",
         title = "어린 왕자",
         author = "앙투안 드 생텍쥐페리",
-        imageUrl = "https://images-ext-1.discordapp.net/external/Dj-FzWSUevc1s_rJdjgHKEDl8VOS4AU-u3-B94EWA9A/https/contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791158511982.jpg?format=webp&width=916&height=1372",
+        imageUrl = "https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791158511982.jpg",
+        status = ReadingStatus.READING,
         totalPage = 132,
         currentPage = 98,
         startDate = LocalDateTime.of(2025, 7, 25, 9, 0),
         endDate = LocalDateTime.of(2025, 7, 29, 10, 0),
-        totalReadTime = 521312423,
-        status = ReadingStatus.READING,
+        totalReadTime = 18000,
         review = "짧지만 깊은 울림이 있는 책",
         rating = 4.5,
-        createdAt = LocalDateTime.of(2025, 7, 25, 8, 50)
-    )
+        category = null,
+        publisher = null,
+        isbn13 = null,
+        description = null,
+    ),
 )
 
 val dummyQuotes = listOf(
-    Quote(
+    QuoteUiModel(
         id = "q1",
-        userId = "user_123",
-        userBookId = "ub1",
         content = "진정한 용기는 두려움을 이겨내는 것이다.",
         pageNumber = 45,
         isLiked = false,
@@ -55,12 +55,10 @@ val dummyQuotes = listOf(
         title = "용기의 심리학",
         author = "브레네 브라운",
         publisher = "마음출판사",
-        imageUrl = "https://example.com/image1.jpg"
+        imageUrl = "https://example.com/image1.jpg",
     ),
-    Quote(
+    QuoteUiModel(
         id = "q2",
-        userId = "user_123",
-        userBookId = "ub1",
         content = "꾸준함이 재능을 이긴다.",
         pageNumber = 88,
         isLiked = true,
@@ -68,45 +66,15 @@ val dummyQuotes = listOf(
         title = "습관의 힘",
         author = "찰스 두히그",
         publisher = "갤럭시북스",
-        imageUrl = "https://example.com/image2.jpg"
+        imageUrl = "https://example.com/image2.jpg",
     ),
-    Quote(
-        id = "q3",
-        userId = "user_123",
-        userBookId = "ub2",
-        content = "가장 어두운 밤도 끝나고 해는 뜬다.",
-        pageNumber = 123,
-        isLiked = false,
-        createdAt = LocalDateTime.now().minusHours(5),
-        title = "레미제라블",
-        author = "빅토르 위고",
-        publisher = "고전문학사",
-        imageUrl = "https://example.com/image3.jpg"
-    ),
-    Quote(
-        id = "q4",
-        userId = "user_123",
-        userBookId = "ub3",
-        content = "행복은 결과가 아니라 과정이다.",
-        pageNumber = 12,
-        isLiked = true,
-        createdAt = LocalDateTime.now().minusDays(3),
-        title = "행복의 기원",
-        author = "서은국",
-        publisher = "21세기북스",
-        imageUrl = "https://example.com/image4.jpg"
-    ),
-    Quote(
-        id = "q5",
-        userId = "user_123",
-        userBookId = "ub4",
-        content = "생각은 말로, 말은 행동으로 이어진다.",
-        pageNumber = null,
-        isLiked = false,
-        createdAt = LocalDateTime.now(),
-        title = "생각의 지도",
-        author = "리처드 니스벳",
-        publisher = "열린책들",
-        imageUrl = "https://example.com/image5.jpg"
-    )
+)
+
+val mockHomeUiModel = HomeUiModel(
+    nickname = "히히히히",
+    appellation = "새벽독서가",
+    dailyGoalTime = 3600,
+    userBooks = mockUserBooks,
+    quotes = dummyQuotes,
+    todayReadTime = 1800,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabPosition
 import androidx.compose.material3.TabRow
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -39,20 +38,19 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.domain.model.ReadingStatus
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.Medi16Text
 import com.hihihihi.presentation.designsystem.components.Semi18Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
-import com.hihihihi.presentation.navigation.NavigationRoute
 import com.hihihihi.presentation.ui.library.component.BookItem
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 
 @Composable
 fun LibraryScreen(
-    navController: NavHostController,
+    onNavigateToBookDetail: (String) -> Unit,
     viewModel: LibraryViewModel = hiltViewModel()
 ) {
     val tabTitles = listOf("읽기 전", "읽는 중", "읽은 후")
@@ -184,13 +182,7 @@ fun LibraryScreen(
                                         items(plannedBooks) { book ->
                                             BookItem(
                                                 book = book,
-                                                onClicked = {
-                                                    navController.navigate(
-                                                        NavigationRoute.BookDetail.createRoute(
-                                                            it
-                                                        )
-                                                    )
-                                                }
+                                                onClicked = { onNavigateToBookDetail(it) }
                                             )
                                         }
                                     }
@@ -230,13 +222,7 @@ fun LibraryScreen(
                                         items(readingBooks) { book ->
                                             BookItem(
                                                 book = book,
-                                                onClicked = {
-                                                    navController.navigate(
-                                                        NavigationRoute.BookDetail.createRoute(
-                                                            it
-                                                        )
-                                                    )
-                                                }
+                                                onClicked = { onNavigateToBookDetail(it) }
                                             )
                                         }
                                     }
@@ -274,13 +260,7 @@ fun LibraryScreen(
                                         items(finishedBooks) { book ->
                                             BookItem(
                                                 book = book,
-                                                onClicked = {
-                                                    navController.navigate(
-                                                        NavigationRoute.BookDetail.createRoute(
-                                                            it
-                                                        )
-                                                    )
-                                                }
+                                                onClicked = { onNavigateToBookDetail(it) }
                                             )
                                         }
                                     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryScreen.kt
@@ -1,5 +1,6 @@
 package com.hihihihi.presentation.ui.library
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -33,6 +34,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
@@ -43,26 +45,40 @@ import com.hihihihi.domain.model.ReadingStatus
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.Medi16Text
 import com.hihihihi.presentation.designsystem.components.Semi18Text
+import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.library.component.BookItem
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 import kotlinx.coroutines.launch
+import kotlin.collections.filter
 import kotlin.math.abs
 
 @Composable
 fun LibraryScreen(
     onNavigateToBookDetail: (String) -> Unit,
-    viewModel: LibraryViewModel = hiltViewModel()
+    viewModel: LibraryViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    LibraryContent(
+        books = uiState.books,
+        errorMessage = uiState.errorMessage,
+        onNavigateToBookDetail = onNavigateToBookDetail,
+    )
+}
+
+@Composable
+private fun LibraryContent(
+    books: List<UserBookUiModel>,
+    errorMessage: String?,
+    onNavigateToBookDetail: (String) -> Unit,
 ) {
     val tabTitles = listOf("읽기 전", "읽는 중", "읽은 후")
-
     val pagerState = rememberPagerState(pageCount = { tabTitles.size })
     val scope = rememberCoroutineScope()
 
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
-    val plannedBooks = uiState.books.filter { it.status == ReadingStatus.PLANNED }
-    val readingBooks = uiState.books.filter { it.status == ReadingStatus.READING }
-    val finishedBooks = uiState.books.filter { it.status == ReadingStatus.FINISHED }
+    val plannedBooks = books.filter { it.status == ReadingStatus.PLANNED }
+    val readingBooks = books.filter { it.status == ReadingStatus.READING }
+    val finishedBooks = books.filter { it.status == ReadingStatus.FINISHED }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -134,7 +150,7 @@ fun LibraryScreen(
                     state = pagerState,
                     modifier = Modifier.fillMaxSize()
                 ) { page ->
-                    if (uiState.errorMessage != null) {
+                    if (errorMessage != null) {
                         Column(
                             modifier = Modifier.fillMaxSize(),
                             horizontalAlignment = Alignment.CenterHorizontally,
@@ -321,5 +337,79 @@ private fun SlidingPillIndicator(
                 .background(GureumTheme.colors.primary)
                 .zIndex(-1f)
         )
+    }
+}
+
+@Preview(name = "Empty - Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Empty - Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LibraryEmptyPreview() {
+    GureumPageTheme {
+        LibraryContent(books = emptyList(), errorMessage = null, onNavigateToBookDetail = {})
+    }
+}
+
+@Preview(name = "WithBooks - Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "WithBooks - Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LibraryWithBooksPreview() {
+    val sampleBooks = listOf(
+        UserBookUiModel(
+            userBookId = "1",
+            title = "데미안",
+            author = "헤르만 헤세",
+            imageUrl = "",
+            status = ReadingStatus.PLANNED,
+            currentPage = 0,
+            totalPage = 250,
+            startDate = null,
+            endDate = null,
+            totalReadTime = 0,
+            rating = null,
+            review = null,
+            category = "소설",
+            publisher = "민음사",
+            isbn13 = "1234567890123",
+            description = "나를 찾아가는 길"
+        ),
+        UserBookUiModel(
+            userBookId = "2",
+            title = "코틀린 입문",
+            author = "작가 미상",
+            imageUrl = "",
+            status = ReadingStatus.READING,
+            currentPage = 50,
+            totalPage = 400,
+            startDate = null,
+            endDate = null,
+            totalReadTime = 120,
+            rating = null,
+            review = null,
+            category = "IT",
+            publisher = "출판사",
+            isbn13 = "9876543210987",
+            description = "코틀린은 즐거워"
+        ),
+        UserBookUiModel(
+            userBookId = "3",
+            title = "클린 아키텍처",
+            author = "로버트 C. 마틴",
+            imageUrl = "",
+            status = ReadingStatus.FINISHED,
+            currentPage = 350,
+            totalPage = 350,
+            startDate = null,
+            endDate = null,
+            totalReadTime = 600,
+            rating = 5.0,
+            review = "훌륭한 책입니다.",
+            category = "IT",
+            publisher = "인사이트",
+            isbn13 = "1122334455667",
+            description = "소프트웨어 구조에 대하여"
+        )
+    )
+    GureumPageTheme {
+        LibraryContent(books = sampleBooks, errorMessage = null, onNavigateToBookDetail = {})
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabPosition
 import androidx.compose.material3.TabRow
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -60,7 +60,7 @@ fun LibraryScreen(
     val pagerState = rememberPagerState(pageCount = { tabTitles.size })
     val scope = rememberCoroutineScope()
 
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val plannedBooks = uiState.books.filter { it.status == ReadingStatus.PLANNED }
     val readingBooks = uiState.books.filter { it.status == ReadingStatus.READING }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryUiState.kt
@@ -1,10 +1,9 @@
 package com.hihihihi.presentation.ui.library
 
-import com.hihihihi.domain.model.UserBook
+import com.hihihihi.presentation.ui.model.UserBookUiModel
 
-//서재 화면 ui 상태 모델
 data class LibraryUiState(
-    val isLoading: Boolean = false, // 데이터 로딩 중인지
-    val books: List<UserBook> = emptyList(), // 유저의 책 목록
-    val errorMessage: String? = null // 에러 발생 시 메시지 (null이면 에러 없음)
+    val isLoading: Boolean = false,
+    val books: List<UserBookUiModel> = emptyList(),
+    val errorMessage: String? = null,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -32,21 +33,15 @@ class LibraryViewModel @Inject constructor(
     fun loadUserBooks(userId: String) {
         viewModelScope.launch {
             try {
-                //로딩 상태
-                _uiState.value = LibraryUiState(isLoading = true)
-                //책 목록 Flow 수집해서 ui 상태 갱신
+                // 로딩 상태
+                _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                // 책 목록 Flow 수집해서 ui 상태 갱신
                 getUserBooksUseCase(userId).collect { books ->
-                    _uiState.value = LibraryUiState(
-                        isLoading = false,
-                        books = books.map { it.toUiModel() },
-                    )
+                    _uiState.update { it.copy(isLoading = false, books = books.map { book -> book.toUiModel() }) }
                 }
             } catch (e: Exception) {
-                //에러 발생 시 ui 상태에 에러 메시지 전달
-                _uiState.value = LibraryUiState(
-                    isLoading = false,
-                    errorMessage = e.message ?: "알 수 없는 오류 발생",
-                )
+                // 에러 발생 시 ui 상태에 에러 메시지 전달
+                _uiState.update { it.copy(isLoading = false, errorMessage = e.message ?: "알 수 없는 오류 발생") }
             }
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/library/LibraryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hihihihi.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.hihihihi.domain.usecase.userbook.GetUserBooksUseCase
+import com.hihihihi.presentation.ui.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,7 +15,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
     private val getUserBooksUseCase: GetUserBooksUseCase, // 유저 책 목록 가져오는 UseCase
-    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
 ) : ViewModel() {
 
     // ui 상태 :
@@ -37,14 +38,14 @@ class LibraryViewModel @Inject constructor(
                 getUserBooksUseCase(userId).collect { books ->
                     _uiState.value = LibraryUiState(
                         isLoading = false,
-                        books = books
+                        books = books.map { it.toUiModel() },
                     )
                 }
             } catch (e: Exception) {
                 //에러 발생 시 ui 상태에 에러 메시지 전달
                 _uiState.value = LibraryUiState(
                     isLoading = false,
-                    errorMessage = e.message ?: "알 수 없는 오류 발생"
+                    errorMessage = e.message ?: "알 수 없는 오류 발생",
                 )
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/library/component/BookItem.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/library/component/BookItem.kt
@@ -23,34 +23,28 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.ReadingStatus
-import com.hihihihi.domain.model.UserBook
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.BookCoverImage
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
+import com.hihihihi.presentation.ui.model.UserBookUiModel
+import com.hihihihi.presentation.ui.model.isRead
 
-fun UserBook.isRead(): Boolean = this.status == ReadingStatus.FINISHED
-
-//한 권의 책정보
 @Composable
-fun BookItem(book: UserBook, onClicked: (String) -> Unit) {
+fun BookItem(book: UserBookUiModel, onClicked: (String) -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .padding(8.dp)
-            .clickable { onClicked(book.userBookId) }
+            .clickable { onClicked(book.userBookId) },
     ) {
         val iconSize = 16.dp
-        val offsetX = iconSize / 2 // 오른쪽으로 아이콘 크기의 절반 만큼 이동
-        val offsetY = -iconSize / 2 // 위쪽으로 아이콘 크기의 절반 만큼 이동
+        val offsetX = iconSize / 2
+        val offsetY = -iconSize / 2
 
-        // 책 카드 ui
         Column(
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalAlignment = Alignment.Start
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.Start,
         ) {
-            //이미지
             BookCoverImage(
                 imageUrl = book.imageUrl,
                 modifier = Modifier
@@ -58,42 +52,35 @@ fun BookItem(book: UserBook, onClicked: (String) -> Unit) {
                     .aspectRatio(2f / 3f)
                     .clip(RoundedCornerShape(8.dp)),
             )
-
             Spacer(modifier = Modifier.height(8.dp))
-
-            //제목
             Text(
                 text = book.title,
                 style = MaterialTheme.typography.bodyMedium,
                 color = GureumTheme.colors.gray800,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
-
             Spacer(modifier = Modifier.height(2.dp))
-
-            //작가
             Text(
                 text = book.author,
                 style = MaterialTheme.typography.bodySmall,
                 color = GureumTheme.colors.gray500,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
         }
 
-        //다 읽은 책 아이콘
         if (book.isRead()) {
             Image(
                 painter = painterResource(id = R.drawable.ic_finish_stamp),
                 contentDescription = null,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .offset(x = offsetX, y = offsetY) // 살짝 겹쳐 보이게 끔 위치 조정
+                    .offset(x = offsetX, y = offsetY)
                     .size(36.dp),
-                colorFilter = ColorFilter.tint(GureumTheme.colors.primary, blendMode = BlendMode.SrcIn)
+                colorFilter = ColorFilter.tint(GureumTheme.colors.primary, blendMode = BlendMode.SrcIn),
             )
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -36,7 +35,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.hihihihi.domain.usecase.auth.SocialProvider
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.Medi12Text
@@ -51,7 +53,8 @@ import kotlinx.coroutines.launch
 @SuppressLint("ContextCastToActivity")
 @Composable
 fun LoginScreen(
-    navController: NavHostController,
+    onNavigateToHome: () -> Unit,
+    onNavigateToOnBoarding: () -> Unit,
     viewModel: LoginViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -59,12 +62,24 @@ fun LoginScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     val googleLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
     ) { result ->
         result.data?.let { intent ->
-            viewModel.handleGoogleSignInResult(intent, navController)
+            viewModel.handleGoogleSignInResult(intent)
+        }
+    }
+
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.effect.collect { effect ->
+                when (effect) {
+                    LoginEffect.NavigateToHome -> onNavigateToHome()
+                    LoginEffect.NavigateToOnBoarding -> onNavigateToOnBoarding()
+                }
+            }
         }
     }
 
@@ -152,7 +167,7 @@ fun LoginScreen(
                     coroutineScope.launch {
                         runCatching { SocialLoginManager.loginWithKakao(context) }
                             .onSuccess { token ->
-                                viewModel.loginWithSocialToken(SocialProvider.KAKAO, token, navController)
+                                viewModel.loginWithSocialToken(SocialProvider.KAKAO, token)
                             }
                             .onFailure { viewModel.setError("카카오 로그인에 실패했습니다.") }
                     }
@@ -172,7 +187,7 @@ fun LoginScreen(
                     coroutineScope.launch {
                         runCatching { SocialLoginManager.loginWithNaver(act) }
                             .onSuccess { token ->
-                                viewModel.loginWithSocialToken(SocialProvider.NAVER, token, navController)
+                                viewModel.loginWithSocialToken(SocialProvider.NAVER, token)
                             }
                             .onFailure { viewModel.setError("네이버 로그인에 실패했습니다.") }
                     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -44,6 +45,7 @@ import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.Medi12Text
 import com.hihihihi.presentation.designsystem.components.Medi14Text
 import com.hihihihi.presentation.designsystem.components.Semi16Text
+import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.ui.login.components.SocialLoginButton
@@ -55,7 +57,7 @@ import kotlinx.coroutines.launch
 fun LoginScreen(
     onNavigateToHome: () -> Unit,
     onNavigateToOnBoarding: () -> Unit,
-    viewModel: LoginViewModel = hiltViewModel()
+    viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val activity = LocalContext.current as? Activity
@@ -65,11 +67,9 @@ fun LoginScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
 
     val googleLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult()
+        contract = ActivityResultContracts.StartActivityForResult(),
     ) { result ->
-        result.data?.let { intent ->
-            viewModel.handleGoogleSignInResult(intent)
-        }
+        result.data?.let { intent -> viewModel.handleGoogleSignInResult(intent) }
     }
 
     LaunchedEffect(lifecycleOwner) {
@@ -89,6 +89,41 @@ fun LoginScreen(
             viewModel.clearError()
         }
     }
+
+    LoginContent(
+        lastProvider = uiState.lastProvider,
+        isLoading = uiState.isLoading,
+        loadingMessage = uiState.loadingMessage,
+        snackbarHostState = snackbarHostState,
+        onGoogleLogin = { viewModel.googleLogin(context, googleLauncher) },
+        onKakaoLogin = {
+            coroutineScope.launch {
+                runCatching { SocialLoginManager.loginWithKakao(context) }
+                    .onSuccess { viewModel.loginWithSocialToken(SocialProvider.KAKAO, it) }
+                    .onFailure { viewModel.setError("카카오 로그인에 실패했습니다.") }
+            }
+        },
+        onNaverLogin = {
+            val act = activity ?: return@LoginContent
+            coroutineScope.launch {
+                runCatching { SocialLoginManager.loginWithNaver(act) }
+                    .onSuccess { viewModel.loginWithSocialToken(SocialProvider.NAVER, it) }
+                    .onFailure { viewModel.setError("네이버 로그인에 실패했습니다.") }
+            }
+        },
+    )
+}
+
+@Composable
+private fun LoginContent(
+    lastProvider: String?,
+    isLoading: Boolean,
+    loadingMessage: String?,
+    snackbarHostState: SnackbarHostState,
+    onGoogleLogin: () -> Unit,
+    onKakaoLogin: () -> Unit,
+    onNaverLogin: () -> Unit,
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -96,104 +131,65 @@ fun LoginScreen(
                 brush = Brush.linearGradient(
                     colors = if (GureumTheme.isDarkTheme) listOf(
                         GureumTheme.colors.background,
-                        Color(0xFF00153F)
+                        Color(0xFF00153F),
                     ) else listOf(
                         Color(0xFF51C1F6),
                         Color(0xFFB3E3F8),
-                        Color(0xFFFFFDE7)
-                    )
-                )
-            )
+                        Color(0xFFFFFDE7),
+                    ),
+                ),
+            ),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
             Image(
                 painter = painterResource(id = R.drawable.ic_cloud_icon),
                 contentDescription = "logo",
-                modifier = Modifier.size(52.dp)
+                modifier = Modifier.size(52.dp),
             )
             Spacer(modifier = Modifier.height(16.dp))
-
             Text(
                 "구름한장",
-                style = GureumTypography.displayMedium.copy(
-                    fontWeight = FontWeight.Bold
-                ),
-                color = GureumTheme.colors.gray900
+                style = GureumTypography.displayMedium.copy(fontWeight = FontWeight.Bold),
+                color = GureumTheme.colors.gray900,
             )
-
             Spacer(modifier = Modifier.height(16.dp))
-
-            Semi16Text(
-                "한 장 한 장 쌓이는",
-                color = GureumTheme.colors.gray700,
-            )
-
+            Semi16Text("한 장 한 장 쌓이는", color = GureumTheme.colors.gray700)
             Spacer(modifier = Modifier.height(4.dp))
-
-            Semi16Text(
-                "나의 소중한 독서 기록",
-                color = GureumTheme.colors.primaryDeep,
-            )
-
+            Semi16Text("나의 소중한 독서 기록", color = GureumTheme.colors.primaryDeep)
             Spacer(modifier = Modifier.height(120.dp))
-
 
             SocialLoginButton(
                 text = "구글 로그인",
                 textColor = Color.Black,
                 iconResId = R.drawable.ic_google,
                 backgroundColor = Color.White,
-                isLastProvider = uiState.lastProvider == "google",
-                onClick = {
-                    viewModel.googleLogin(context, googleLauncher)
-                }
+                isLastProvider = lastProvider == "google",
+                onClick = onGoogleLogin,
             )
-
             Spacer(modifier = Modifier.height(16.dp))
-
             SocialLoginButton(
                 text = "카카오 로그인",
                 textColor = Color.Black,
                 iconResId = R.drawable.ic_kakao,
                 backgroundColor = Color(0xFFFEE500),
-                isLastProvider = uiState.lastProvider == "kakao",
-                onClick = {
-                    coroutineScope.launch {
-                        runCatching { SocialLoginManager.loginWithKakao(context) }
-                            .onSuccess { token ->
-                                viewModel.loginWithSocialToken(SocialProvider.KAKAO, token)
-                            }
-                            .onFailure { viewModel.setError("카카오 로그인에 실패했습니다.") }
-                    }
-                }
+                isLastProvider = lastProvider == "kakao",
+                onClick = onKakaoLogin,
             )
-
             Spacer(modifier = Modifier.height(16.dp))
-
             SocialLoginButton(
                 text = "네이버 로그인",
                 textColor = Color.White,
                 iconResId = R.drawable.ic_naver,
                 backgroundColor = Color(0xFF03C75A),
-                isLastProvider = uiState.lastProvider == "naver",
-                onClick = {
-                    val act = activity ?: return@SocialLoginButton
-                    coroutineScope.launch {
-                        runCatching { SocialLoginManager.loginWithNaver(act) }
-                            .onSuccess { token ->
-                                viewModel.loginWithSocialToken(SocialProvider.NAVER, token)
-                            }
-                            .onFailure { viewModel.setError("네이버 로그인에 실패했습니다.") }
-                    }
-                }
+                isLastProvider = lastProvider == "naver",
+                onClick = onNaverLogin,
             )
-
             Spacer(modifier = Modifier.height(16.dp))
             Medi12Text(
                 "로그인하여 나만의 독서 여정을 시작해보세요 ✨",
@@ -202,36 +198,27 @@ fun LoginScreen(
         }
     }
 
-    if (uiState.isLoading) {
+    if (isLoading) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.Black.copy(alpha = 0.5f)),
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.Center,
         ) {
             Box(
                 modifier = Modifier
-                    .background(
-                        GureumTheme.background.color,
-                        RoundedCornerShape(12.dp)
-                    )
+                    .background(GureumTheme.background.color, RoundedCornerShape(12.dp))
                     .padding(32.dp),
-                contentAlignment = Alignment.Center
+                contentAlignment = Alignment.Center,
             ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(40.dp),
-                        color = GureumTheme.colors.primary
+                        color = GureumTheme.colors.primary,
                     )
-
-                    if (uiState.loadingMessage?.isNotEmpty() == true) {
+                    if (loadingMessage?.isNotEmpty() == true) {
                         Spacer(modifier = Modifier.height(16.dp))
-                        Medi14Text(
-                            text = uiState.loadingMessage!!,
-                            color = GureumTheme.colors.gray700
-                        )
+                        Medi14Text(text = loadingMessage, color = GureumTheme.colors.gray700)
                     }
                 }
             }
@@ -240,13 +227,29 @@ fun LoginScreen(
 
     SnackbarHost(
         hostState = snackbarHostState,
-        modifier = Modifier.statusBarsPadding()
+        modifier = Modifier.statusBarsPadding(),
     ) { data ->
         Snackbar(
             snackbarData = data,
             containerColor = GureumTheme.colors.systemRed,
-            contentColor = Color.White
+            contentColor = Color.White,
         )
     }
+}
 
+@Preview(name = "Light", showBackground = true)
+@Preview(name = "Dark")
+@Composable
+private fun LoginPreview() {
+    GureumPageTheme {
+        LoginContent(
+            lastProvider = "google",
+            isLoading = false,
+            loadingMessage = null,
+            snackbarHostState = SnackbarHostState(),
+            onGoogleLogin = {},
+            onKakaoLogin = {},
+            onNaverLogin = {},
+        )
+    }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
@@ -50,6 +50,7 @@ import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.ui.login.components.SocialLoginButton
 import com.hihihihi.presentation.ui.login.util.SocialLoginManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 @SuppressLint("ContextCastToActivity")
@@ -100,7 +101,10 @@ fun LoginScreen(
             coroutineScope.launch {
                 runCatching { SocialLoginManager.loginWithKakao(context) }
                     .onSuccess { viewModel.loginWithSocialToken(SocialProvider.KAKAO, it) }
-                    .onFailure { viewModel.setError("카카오 로그인에 실패했습니다.") }
+                    .onFailure {
+                        if (it is CancellationException) throw it
+                        viewModel.setError("카카오 로그인에 실패했습니다.")
+                    }
             }
         },
         onNaverLogin = {
@@ -108,7 +112,10 @@ fun LoginScreen(
             coroutineScope.launch {
                 runCatching { SocialLoginManager.loginWithNaver(act) }
                     .onSuccess { viewModel.loginWithSocialToken(SocialProvider.NAVER, it) }
-                    .onFailure { viewModel.setError("네이버 로그인에 실패했습니다.") }
+                    .onFailure {
+                        if (it is CancellationException) throw it
+                        viewModel.setError("네이버 로그인에 실패했습니다.")
+                    }
             }
         },
     )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -56,7 +56,7 @@ fun LoginScreen(
 ) {
     val context = LocalContext.current
     val activity = LocalContext.current as? Activity
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginViewModel.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavHostController
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.hihihihi.domain.usecase.auth.GetCurrentUserIdUseCase
@@ -17,13 +16,15 @@ import com.hihihihi.domain.usecase.user.GetUserUseCase
 import com.hihihihi.domain.usecase.user.SetLastProviderUseCase
 import com.hihihihi.domain.usecase.user.SetOnboardingCompleteUseCase
 import com.hihihihi.domain.usecase.user.WaitForUserDocumentCreationUseCase
-import com.hihihihi.presentation.navigation.NavigationRoute
 import com.hihihihi.presentation.ui.login.util.SocialLoginManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -41,6 +42,9 @@ class LoginViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState
 
+    private val _effect = Channel<LoginEffect>(Channel.BUFFERED)
+    val effect: Flow<LoginEffect> = _effect.receiveAsFlow()
+
     init {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(
@@ -54,7 +58,7 @@ class LoginViewModel @Inject constructor(
         return getLastProviderUseCase().first()
     }
 
-    private suspend fun navigateAfterLogin(navController: NavHostController) {
+    private suspend fun navigateAfterLogin() {
         setLoading(true, "사용자 정보를 설정하는 중...")
 
         val currentUserUid = getCurrentUserIdUseCase()
@@ -78,15 +82,11 @@ class LoginViewModel @Inject constructor(
 
         val isOnboardingComplete = getOnboardingCompleteUseCase(currentUserUid).firstOrNull() ?: false
 
-        val destination = if (isOnboardingComplete && hasNickname) {
-            NavigationRoute.Home.route
+        setLoading(false)
+        if (isOnboardingComplete && hasNickname) {
+            _effect.send(LoginEffect.NavigateToHome)
         } else {
-            NavigationRoute.OnBoarding.route
-        }
-
-        setLoading(true, "사용자 정보를 확인하는 중...")
-        navController.navigate(destination) {
-            popUpTo(NavigationRoute.Login.route) { inclusive = true }
+            _effect.send(LoginEffect.NavigateToOnBoarding)
         }
     }
 
@@ -122,7 +122,6 @@ class LoginViewModel @Inject constructor(
 
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(defaultWebClientId)
-
             .requestEmail()
             .build()
 
@@ -130,34 +129,32 @@ class LoginViewModel @Inject constructor(
         launcher.launch(client.signInIntent)
     }
 
-    fun handleGoogleSignInResult(
-        data: Intent,
-        navController: NavHostController
-    ) {
+    fun handleGoogleSignInResult(data: Intent) {
         viewModelScope.launch {
             try {
                 val idToken = SocialLoginManager.getGoogleIdToken(data)
-                loginWithSocialToken(SocialProvider.GOOGLE, idToken, navController)
+                loginWithSocialToken(SocialProvider.GOOGLE, idToken)
             } catch (_: Exception) {
                 setError("구글 로그인에 실패했습니다. 다시 시도해주세요.")
             }
         }
     }
 
-    fun loginWithSocialToken(
-        provider: SocialProvider,
-        accessToken: String,
-        navController: NavHostController
-    ) {
+    fun loginWithSocialToken(provider: SocialProvider, accessToken: String) {
         viewModelScope.launch {
             try {
                 setLoading(true, "로그인 중...")
                 signInWithSocialTokenUseCase(provider, accessToken)
                 setLastProviderUseCase(provider.name.lowercase())
-                navigateAfterLogin(navController)
+                navigateAfterLogin()
             } catch (_: Exception) {
                 setError("로그인에 실패했습니다. 다시 시도해주세요.")
             }
         }
     }
+}
+
+sealed interface LoginEffect {
+    data object NavigateToHome : LoginEffect
+    data object NavigateToOnBoarding : LoginEffect
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -72,10 +73,13 @@ private fun MindMapContent(
         intArrayOf(ContextCompat.getColor(context, R.color.primary50), ContextCompat.getColor(context, R.color.gray200)),
     )
 
+    val currentIsEditing by rememberUpdatedState(isEditing)
+    val currentOnEndEdit by rememberUpdatedState(onEndEdit)
+
     DisposableEffect(Unit) {
         onDispose {
-            if (isEditing) {
-                onEndEdit(adapter.asDomainList(mindmapId), true)
+            if (currentIsEditing) {
+                currentOnEndEdit(adapter.asDomainList(mindmapId), true)
             }
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapScreen.kt
@@ -34,17 +34,21 @@ fun MindMapScreen(
 ) {
     val context = LocalContext.current
     val adapter = remember { MindMapAdapter(context) }
-    val nodes by viewModel.nodes.collectAsStateWithLifecycle() // 스냅샷
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val nodes = uiState.nodes
     val lineColor = GureumTheme.colors.gray200.toArgb()
 
     val thumbColors = ColorStateList(
         arrayOf(intArrayOf(android.R.attr.state_checked), intArrayOf(-android.R.attr.state_checked)),
-        intArrayOf(ContextCompat.getColor(context, R.color.primary), ContextCompat.getColor(context, R.color.gray300))
+        intArrayOf(ContextCompat.getColor(context, R.color.primary), ContextCompat.getColor(context, R.color.gray300)),
     )
 
     val trackColors = ColorStateList(
         arrayOf(intArrayOf(android.R.attr.state_checked), intArrayOf(-android.R.attr.state_checked)),
-        intArrayOf(ContextCompat.getColor(context, R.color.primary50), ContextCompat.getColor(context, R.color.gray200))
+        intArrayOf(
+            ContextCompat.getColor(context, R.color.primary50),
+            ContextCompat.getColor(context, R.color.gray200)
+        ),
     )
 
     LaunchedEffect(mindmapId) {
@@ -54,7 +58,7 @@ fun MindMapScreen(
     DisposableEffect(Unit) {
         onDispose {
             // 편집 중일때 나가도 자동 저장
-            if (viewModel.editing) {
+            if (uiState.editing) {
                 viewModel.endEdit(adapter.asDomainList(mindmapId), autoSave = true)
             }
         }
@@ -64,7 +68,7 @@ fun MindMapScreen(
         factory = ActivityMindmapBinding::inflate,
         modifier = Modifier
             .fillMaxSize()
-            .navigationBarsPadding()
+            .navigationBarsPadding(),
     ) {
         if (baseTreeView.adapter !is MindMapAdapter) {
             baseTreeView.adapter = adapter
@@ -73,8 +77,8 @@ fun MindMapScreen(
                     context,
                     50,     // 부모 - 자식 간 거리
                     20,       // 노드 간 거리
-                    DashLine(lineColor, 8)
-                )
+                    DashLine(lineColor, 8),
+                ),
             )
             adapter.setEditor(baseTreeView.editor) // 에디터 탑재
         }
@@ -89,7 +93,7 @@ fun MindMapScreen(
         }
 
         // 편집 중이 아닐 때만 원격 스냅샷으로 트리 구성
-        if (!viewModel.editing && nodes.isNotEmpty() && !adapter.sameAs(nodes, mindmapId)) {
+        if (!uiState.editing && nodes.isNotEmpty() && !adapter.sameAs(nodes, mindmapId)) {
             val root = nodes.firstOrNull { it.parentNodeId == null } ?: return@AndroidViewBinding
             val modelRoot = NodeModel(root.toUi())
             val model = TreeModel(modelRoot)
@@ -129,7 +133,7 @@ fun MindMapScreen(
         switchEditMode.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) viewModel.startEdit() else viewModel.endEdit(
                 adapter.asDomainList(mindmapId),
-                autoSave = true
+                autoSave = true,
             )
 
             adapter.changeEditMode(isChecked)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapScreen.kt
@@ -1,6 +1,7 @@
 package com.hihihihi.presentation.ui.mindmap
 
 import android.content.res.ColorStateList
+import android.content.res.Configuration
 import android.view.View
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -13,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
@@ -24,6 +26,7 @@ import com.gyso.treeview.model.TreeModel
 import com.hihihihi.domain.model.MindmapNode
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.databinding.ActivityMindmapBinding
+import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.mindmap.mapper.toUi
 
@@ -32,10 +35,31 @@ fun MindMapScreen(
     mindmapId: String,
     viewModel: MindMapViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(mindmapId) {
+        viewModel.load(mindmapId)
+    }
+
+    MindMapContent(
+        mindmapId = mindmapId,
+        nodes = uiState.nodes,
+        isEditing = uiState.editing,
+        onEndEdit = { list, autoSave -> viewModel.endEdit(list, autoSave) },
+        onStartEdit = viewModel::startEdit,
+    )
+}
+
+@Composable
+private fun MindMapContent(
+    mindmapId: String,
+    nodes: List<MindmapNode>,
+    isEditing: Boolean,
+    onEndEdit: (List<MindmapNode>, Boolean) -> Unit,
+    onStartEdit: () -> Unit,
+) {
     val context = LocalContext.current
     val adapter = remember { MindMapAdapter(context) }
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val nodes = uiState.nodes
     val lineColor = GureumTheme.colors.gray200.toArgb()
 
     val thumbColors = ColorStateList(
@@ -45,21 +69,13 @@ fun MindMapScreen(
 
     val trackColors = ColorStateList(
         arrayOf(intArrayOf(android.R.attr.state_checked), intArrayOf(-android.R.attr.state_checked)),
-        intArrayOf(
-            ContextCompat.getColor(context, R.color.primary50),
-            ContextCompat.getColor(context, R.color.gray200)
-        ),
+        intArrayOf(ContextCompat.getColor(context, R.color.primary50), ContextCompat.getColor(context, R.color.gray200)),
     )
-
-    LaunchedEffect(mindmapId) {
-        viewModel.load(mindmapId)
-    }
 
     DisposableEffect(Unit) {
         onDispose {
-            // 편집 중일때 나가도 자동 저장
-            if (uiState.editing) {
-                viewModel.endEdit(adapter.asDomainList(mindmapId), autoSave = true)
+            if (isEditing) {
+                onEndEdit(adapter.asDomainList(mindmapId), true)
             }
         }
     }
@@ -93,7 +109,7 @@ fun MindMapScreen(
         }
 
         // 편집 중이 아닐 때만 원격 스냅샷으로 트리 구성
-        if (!uiState.editing && nodes.isNotEmpty() && !adapter.sameAs(nodes, mindmapId)) {
+        if (!isEditing && nodes.isNotEmpty() && !adapter.sameAs(nodes, mindmapId)) {
             val root = nodes.firstOrNull { it.parentNodeId == null } ?: return@AndroidViewBinding
             val modelRoot = NodeModel(root.toUi())
             val model = TreeModel(modelRoot)
@@ -131,10 +147,7 @@ fun MindMapScreen(
         btnRedo.setOnClickListener { adapter.redo() }
 
         switchEditMode.setOnCheckedChangeListener { _, isChecked ->
-            if (isChecked) viewModel.startEdit() else viewModel.endEdit(
-                adapter.asDomainList(mindmapId),
-                autoSave = true,
-            )
+            if (isChecked) onStartEdit() else onEndEdit(adapter.asDomainList(mindmapId), true)
 
             adapter.changeEditMode(isChecked)
             btnRedo.visibility = if (isChecked) View.VISIBLE else View.INVISIBLE
@@ -151,4 +164,84 @@ private fun MindMapAdapter.sameAs(nodes: List<MindmapNode>, mindmapId: String): 
     val cur = asDomainList(mindmapId).sortedBy { it.mindmapNodeId }
     val src = nodes.sortedBy { it.mindmapNodeId }
     return cur == src
+}
+
+@Preview(name = "Empty - Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Empty - Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun MindMapEmptyPreview() {
+    GureumPageTheme {
+        MindMapContent(
+            mindmapId = "preview",
+            nodes = emptyList(),
+            isEditing = false,
+            onEndEdit = { _, _ -> },
+            onStartEdit = {},
+        )
+    }
+}
+
+@Preview(name = "WithNodes - Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "WithNodes - Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun MindMapWithNodesPreview() {
+    val sampleNodes = listOf(
+        MindmapNode(
+            userId = "user1",
+            mindmapNodeId = "root",
+            mindmapId = "preview",
+            nodeTitle = "데미안",
+            nodeEx = "헤르만 헤세",
+            parentNodeId = null,
+            color = null,
+            icon = null,
+            deleted = false,
+            bookImage = null
+        ),
+        MindmapNode(
+            userId = "user1",
+            mindmapNodeId = "child1",
+            mindmapId = "preview",
+            nodeTitle = "싱클레어",
+            nodeEx = "주인공",
+            parentNodeId = "root",
+            color = null,
+            icon = null,
+            deleted = false,
+            bookImage = null
+        ),
+        MindmapNode(
+            userId = "user1",
+            mindmapNodeId = "child2",
+            mindmapId = "preview",
+            nodeTitle = "데미안",
+            nodeEx = "인도자",
+            parentNodeId = "root",
+            color = null,
+            icon = null,
+            deleted = false,
+            bookImage = null
+        ),
+        MindmapNode(
+            userId = "user1",
+            mindmapNodeId = "grandchild1",
+            mindmapId = "preview",
+            nodeTitle = "에바 부인",
+            nodeEx = "구원",
+            parentNodeId = "child1",
+            color = null,
+            icon = null,
+            deleted = false,
+            bookImage = null
+        )
+    )
+    GureumPageTheme {
+        MindMapContent(
+            mindmapId = "preview",
+            nodes = sampleNodes,
+            isEditing = false,
+            onEndEdit = { _, _ -> },
+            onStartEdit = {},
+        )
+    }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -34,7 +34,7 @@ fun MindMapScreen(
 ) {
     val context = LocalContext.current
     val adapter = remember { MindMapAdapter(context) }
-    val nodes by viewModel.nodes.collectAsState() // 스냅샷
+    val nodes by viewModel.nodes.collectAsStateWithLifecycle() // 스냅샷
     val lineColor = GureumTheme.colors.gray200.toArgb()
 
     val thumbColors = ColorStateList(

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mindmap/MindMapViewModel.kt
@@ -1,8 +1,5 @@
 package com.hihihihi.presentation.ui.mindmap
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hihihihi.domain.model.MindmapNode
@@ -12,60 +9,63 @@ import com.hihihihi.domain.usecase.mindmapnode.ObserveMindmapNodeUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+data class MindMapUiState(
+    val nodes: List<MindmapNode> = emptyList(),
+    val editing: Boolean = false,
+)
+
 @HiltViewModel
 class MindMapViewModel @Inject constructor(
-    private val observeMindmapNodeUseCase: ObserveMindmapNodeUseCase,  // 노드 실시간 스트림
-    private val applyNodeOperation: ApplyNodeOperation,     // 일괄 변경 적용
+    private val observeMindmapNodeUseCase: ObserveMindmapNodeUseCase,
+    private val applyNodeOperation: ApplyNodeOperation,
 ) : ViewModel() {
-    // 화면에 그릴 스냅샷 노드들
-    private val _nodes = MutableStateFlow<List<MindmapNode>>(emptyList())
-    val nodes: StateFlow<List<MindmapNode>> = _nodes
+
+    private val _uiState = MutableStateFlow(MindMapUiState())
+    val uiState: StateFlow<MindMapUiState> = _uiState.asStateFlow()
 
     // 편집 시작 시점 스냅샷
     private var baseline: List<MindmapNode> = emptyList()
 
-    // observe 수신, 저장이 충돌하지 않게하는 플래그
-    private var saving by mutableStateOf(false)
+    // observe 수신과 저장이 충돌하지 않게 하는 플래그
+    private var saving = false
 
-    var editing by mutableStateOf(false)
-        private set
     lateinit var mindmapId: String
         private set
 
-    // 마인드맵 로드
     fun load(mindmapId: String) {
         this.mindmapId = mindmapId
         viewModelScope.launch {
-            // 편집중이거나 수정중이 아닐 떄 덮어씀
-            observeMindmapNodeUseCase(mindmapId).collect { if (!editing && !saving) _nodes.value = it }
+            observeMindmapNodeUseCase(mindmapId).collect { nodes ->
+                if (!_uiState.value.editing && !saving) {
+                    _uiState.update { it.copy(nodes = nodes) }
+                }
+            }
         }
     }
 
-    // 편집 시작. 현재 화면 상태를 baseLine으로 고정
     fun startEdit() {
-        editing = true
-        baseline = _nodes.value
+        baseline = _uiState.value.nodes
+        _uiState.update { it.copy(editing = true) }
     }
 
-    // 편집 종료. 로컬과 서버 연동
     fun endEdit(currentTree: List<MindmapNode>, autoSave: Boolean = true) {
-        if (!editing) return
+        if (!_uiState.value.editing) return
         viewModelScope.launch {
             if (autoSave) {
                 flushDiff(currentTree)
-                _nodes.value = currentTree
+                _uiState.update { it.copy(nodes = currentTree) }
             }
-            editing = false
+            _uiState.update { it.copy(editing = false) }
         }
     }
 
-    // baseLine과 현재 노드 차이 계산해 서버에 적용
     private suspend fun flushDiff(current: List<MindmapNode>) {
         val operations = diff(baseline, current)
-
         if (operations.isEmpty()) return
         saving = true
         try {
@@ -75,16 +75,13 @@ class MindMapViewModel @Inject constructor(
         }
     }
 
-    // 두 스냅샷 차이를 계산
     private fun diff(oldList: List<MindmapNode>, newList: List<MindmapNode>): List<NodeEditOperation> {
         val old = oldList.associateBy { it.mindmapNodeId }
         val neu = newList.associateBy { it.mindmapNodeId }
         val operations = mutableListOf<NodeEditOperation>()
 
-        // 삭제
         for ((id, _) in old) if (id !in neu) operations += NodeEditOperation.Delete(id)
 
-        // 추가/수정
         for ((id, n) in neu) {
             val o = old[id]
             if (o == null) {

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/HistoryUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/HistoryUiModel.kt
@@ -1,0 +1,23 @@
+package com.hihihihi.presentation.ui.model
+
+import com.hihihihi.domain.model.History
+import com.hihihihi.domain.model.RecordType
+import java.time.LocalDateTime
+
+data class HistoryUiModel(
+    val readTime: Int,
+    val readPageCount: Int,
+    val date: LocalDateTime?,
+    val startTime: LocalDateTime?,
+    val endTime: LocalDateTime?,
+    val recordType: RecordType,
+)
+
+fun History.toUiModel() = HistoryUiModel(
+    readTime = readTime,
+    readPageCount = readPageCount,
+    date = date,
+    startTime = startTime,
+    endTime = endTime,
+    recordType = recordType,
+)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/HomeUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/HomeUiModel.kt
@@ -1,7 +1,9 @@
 package com.hihihihi.presentation.ui.model
 
+import androidx.compose.runtime.Immutable
 import com.hihihihi.domain.usecase.user.HomeData
 
+@Immutable
 data class HomeUiModel(
     val nickname: String,
     val appellation: String,

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/HomeUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/HomeUiModel.kt
@@ -1,0 +1,21 @@
+package com.hihihihi.presentation.ui.model
+
+import com.hihihihi.domain.usecase.user.HomeData
+
+data class HomeUiModel(
+    val nickname: String,
+    val appellation: String,
+    val dailyGoalTime: Int,
+    val userBooks: List<UserBookUiModel>,
+    val quotes: List<QuoteUiModel>,
+    val todayReadTime: Int,
+)
+
+fun HomeData.toUiModel() = HomeUiModel(
+    nickname = user.nickname,
+    appellation = user.appellation,
+    dailyGoalTime = user.dailyGoalTime,
+    userBooks = userBooks.map { it.toUiModel() },
+    quotes = quotes.map { it.toUiModel() },
+    todayReadTime = todayReadTime,
+)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/MyPageUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/MyPageUiModel.kt
@@ -1,0 +1,24 @@
+package com.hihihihi.presentation.ui.model
+
+import com.hihihihi.domain.usecase.user.MyPageData
+import java.time.LocalDate
+
+data class MyPageUiModel(
+    val nickname: String?,
+    val appellation: String?,
+    val provider: String?,
+    val readingStats: Map<LocalDate, Int>,
+    val totalBooks: Int,
+    val totalPages: Int,
+    val totalReadMinutes: Int,
+)
+
+fun MyPageData.toUiModel() = MyPageUiModel(
+    nickname = user?.nickname,
+    appellation = user?.appellation,
+    provider = user?.provider,
+    readingStats = readingStats,
+    totalBooks = totalBooks,
+    totalPages = totalPages,
+    totalReadMinutes = totalReadMinutes,
+)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/MyPageUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/MyPageUiModel.kt
@@ -1,8 +1,10 @@
 package com.hihihihi.presentation.ui.model
 
+import androidx.compose.runtime.Immutable
 import com.hihihihi.domain.usecase.user.MyPageData
 import java.time.LocalDate
 
+@Immutable
 data class MyPageUiModel(
     val nickname: String?,
     val appellation: String?,

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/QuoteUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/QuoteUiModel.kt
@@ -1,8 +1,10 @@
 package com.hihihihi.presentation.ui.model
 
+import androidx.compose.runtime.Immutable
 import com.hihihihi.domain.model.Quote
 import java.time.LocalDateTime
 
+@Immutable
 data class QuoteUiModel(
     val id: String,
     val content: String,

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/QuoteUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/QuoteUiModel.kt
@@ -1,0 +1,28 @@
+package com.hihihihi.presentation.ui.model
+
+import com.hihihihi.domain.model.Quote
+import java.time.LocalDateTime
+
+data class QuoteUiModel(
+    val id: String,
+    val content: String,
+    val pageNumber: Int?,
+    val isLiked: Boolean,
+    val createdAt: LocalDateTime?,
+    val title: String,
+    val author: String,
+    val publisher: String,
+    val imageUrl: String,
+)
+
+fun Quote.toUiModel() = QuoteUiModel(
+    id = id,
+    content = content,
+    pageNumber = pageNumber,
+    isLiked = isLiked,
+    createdAt = createdAt,
+    title = title,
+    author = author,
+    publisher = publisher,
+    imageUrl = imageUrl,
+)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/UserBookUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/UserBookUiModel.kt
@@ -1,9 +1,11 @@
 package com.hihihihi.presentation.ui.model
 
+import androidx.compose.runtime.Immutable
 import com.hihihihi.domain.model.ReadingStatus
 import com.hihihihi.domain.model.UserBook
 import java.time.LocalDateTime
 
+@Immutable
 data class UserBookUiModel(
     val userBookId: String,
     val title: String,

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/model/UserBookUiModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/model/UserBookUiModel.kt
@@ -1,0 +1,45 @@
+package com.hihihihi.presentation.ui.model
+
+import com.hihihihi.domain.model.ReadingStatus
+import com.hihihihi.domain.model.UserBook
+import java.time.LocalDateTime
+
+data class UserBookUiModel(
+    val userBookId: String,
+    val title: String,
+    val author: String,
+    val imageUrl: String,
+    val status: ReadingStatus,
+    val currentPage: Int,
+    val totalPage: Int,
+    val startDate: LocalDateTime?,
+    val endDate: LocalDateTime?,
+    val totalReadTime: Int,
+    val rating: Double?,
+    val review: String?,
+    val category: String?,
+    val publisher: String?,
+    val isbn13: String?,
+    val description: String?,
+)
+
+fun UserBookUiModel.isRead() = status == ReadingStatus.FINISHED
+
+fun UserBook.toUiModel() = UserBookUiModel(
+    userBookId = userBookId,
+    title = title,
+    author = author,
+    imageUrl = imageUrl,
+    status = status,
+    currentPage = currentPage,
+    totalPage = totalPage,
+    startDate = startDate,
+    endDate = endDate,
+    totalReadTime = totalReadTime,
+    rating = rating,
+    review = review,
+    category = category,
+    publisher = publisher,
+    isbn13 = isbn13,
+    description = description,
+)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,20 +23,25 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import com.hihihihi.domain.model.GureumThemeType
 import com.hihihihi.presentation.designsystem.components.Medi14Text
 import com.hihihihi.presentation.designsystem.components.Semi16Text
+import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
+import com.hihihihi.presentation.ui.model.MyPageUiModel
 import com.hihihihi.presentation.ui.mypage.component.MyPageCalenderSection
 import com.hihihihi.presentation.ui.mypage.component.MyPageMenuSection
 import com.hihihihi.presentation.ui.mypage.component.MyPageUserProfileCard
 import com.hihihihi.presentation.ui.mypage.component.NicknameChangeDialog
 import com.hihihihi.presentation.utils.formatSecondsToReadableTimeWithoutSecond
+import java.time.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,8 +50,8 @@ fun MyPageScreen(
     onNavigateToWithdraw: (String) -> Unit,
     viewModel: MypageViewModel = hiltViewModel(),
 ) {
-    val colors = GureumTheme.colors
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val theme by viewModel.theme.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
 
     LaunchedEffect(lifecycleOwner) {
@@ -60,6 +65,43 @@ fun MyPageScreen(
         }
     }
 
+    MyPageContent(
+        isLoading = state.isLoading,
+        errorMessage = state.errorMessage,
+        myPageUiModel = state.myPageUiModel,
+        dialogState = state.dialogState,
+        theme = theme,
+        onThemeToggle = viewModel::toggleTheme,
+        onNicknameChangeClick = viewModel::onNicknameChangeClick,
+        onLogoutClick = viewModel::onLogoutClick,
+        onWithdrawClick = viewModel::onWithdrawClick,
+        onDismissDialog = viewModel::dismissDialog,
+        onChangeNickname = { new ->
+            viewModel.changeNickname(new)
+            viewModel.dismissDialog()
+        },
+        onLogout = viewModel::logout,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MyPageContent(
+    isLoading: Boolean,
+    errorMessage: String?,
+    myPageUiModel: MyPageUiModel?,
+    dialogState: MyPageDialogState,
+    theme: GureumThemeType,
+    onThemeToggle: (GureumThemeType) -> Unit,
+    onNicknameChangeClick: () -> Unit,
+    onLogoutClick: () -> Unit,
+    onWithdrawClick: () -> Unit,
+    onDismissDialog: () -> Unit,
+    onChangeNickname: (String) -> Unit,
+    onLogout: () -> Unit,
+) {
+    val colors = GureumTheme.colors
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -69,7 +111,7 @@ fun MyPageScreen(
         Spacer(modifier = Modifier.height(24.dp))
 
         when {
-            state.isLoading -> Box(
+            isLoading -> Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = 32.dp),
@@ -78,7 +120,7 @@ fun MyPageScreen(
                 CircularProgressIndicator()
             }
 
-            state.errorMessage != null -> {
+            errorMessage != null -> {
                 Column(
                     modifier = Modifier.fillMaxSize(),
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -89,9 +131,7 @@ fun MyPageScreen(
                         color = GureumTheme.colors.gray600,
                         textAlign = TextAlign.Center,
                     )
-
                     Spacer(modifier = Modifier.height(8.dp))
-
                     Medi14Text(
                         text = "잠시 후 다시 시도해주세요",
                         color = GureumTheme.colors.gray500,
@@ -100,8 +140,8 @@ fun MyPageScreen(
                 }
             }
 
-            state.myPageUiModel != null -> {
-                val data = state.myPageUiModel!!
+            myPageUiModel != null -> {
+                val data = myPageUiModel
                 val timeText = remember(data.totalReadMinutes) {
                     formatSecondsToReadableTimeWithoutSecond(data.totalReadMinutes * 60)
                 }
@@ -114,45 +154,37 @@ fun MyPageScreen(
                     totalPages = "${data.totalPages}쪽",
                     totalBooks = "${data.totalBooks}권",
                     totalTime = timeText,
-                    onEditNicknameClick = viewModel::onNicknameChangeClick,
+                    onEditNicknameClick = onNicknameChangeClick,
                 )
             }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
-
-        MyPageCalenderSection(stats = state.myPageUiModel?.readingStats ?: emptyMap())
-
+        MyPageCalenderSection(stats = myPageUiModel?.readingStats ?: emptyMap())
         Spacer(modifier = Modifier.height(28.dp))
-
-        Divider(
-            thickness = 8.dp,
-            color = colors.background10,
-        )
-
+        HorizontalDivider(thickness = 8.dp, color = colors.background10)
         MyPageMenuSection(
-            onLogoutClick = viewModel::onLogoutClick,
-            onWithDrawClick = viewModel::onWithdrawClick,
+            theme = theme,
+            onThemeToggle = onThemeToggle,
+            onLogoutClick = onLogoutClick,
+            onWithDrawClick = onWithdrawClick
         )
     }
 
-    when (state.dialogState) {
+    when (dialogState) {
         MyPageDialogState.None -> Unit
 
         MyPageDialogState.NicknameChange -> {
             NicknameChangeDialog(
-                currentNickname = state.myPageUiModel?.nickname ?: "",
-                onDismiss = viewModel::dismissDialog,
-                onSave = { new ->
-                    viewModel.changeNickname(new)
-                    viewModel.dismissDialog()
-                },
+                currentNickname = myPageUiModel?.nickname ?: "",
+                onDismiss = onDismissDialog,
+                onSave = onChangeNickname,
             )
         }
 
         MyPageDialogState.Logout -> {
             AlertDialog(
-                onDismissRequest = viewModel::dismissDialog,
+                onDismissRequest = onDismissDialog,
                 title = { Semi16Text("로그아웃") },
                 text = { Medi14Text("정말 로그아웃 하실건가요?") },
                 containerColor = GureumTheme.colors.card,
@@ -162,7 +194,7 @@ fun MyPageScreen(
                         color = GureumTheme.colors.systemRed,
                         modifier = Modifier
                             .padding(8.dp)
-                            .clickable { viewModel.logout() },
+                            .clickable { onLogout() },
                     )
                 },
                 dismissButton = {
@@ -171,10 +203,45 @@ fun MyPageScreen(
                         color = GureumTheme.colors.gray500,
                         modifier = Modifier
                             .padding(8.dp)
-                            .clickable { viewModel.dismissDialog() },
+                            .clickable { onDismissDialog() },
                     )
                 },
             )
         }
+    }
+}
+
+@Preview(name = "DarkMode", uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "LightMode", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_NO)
+@Composable
+private fun MyPageWithDataPreview() {
+    val sampleData = MyPageUiModel(
+        nickname = "구름이",
+        appellation = "독서왕",
+        provider = "google",
+        readingStats = mapOf(
+            LocalDate.now().minusDays(2) to 50,
+            LocalDate.now().minusDays(1) to 120,
+            LocalDate.now() to 80,
+        ),
+        totalBooks = 12,
+        totalPages = 3450,
+        totalReadMinutes = 1250,
+    )
+    GureumPageTheme {
+        MyPageContent(
+            isLoading = false,
+            errorMessage = null,
+            myPageUiModel = sampleData,
+            dialogState = MyPageDialogState.None,
+            theme = GureumThemeType.DARK,
+            onThemeToggle = {},
+            onNicknameChangeClick = {},
+            onLogoutClick = {},
+            onWithdrawClick = {},
+            onDismissDialog = {},
+            onChangeNickname = {},
+            onLogout = {},
+        )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageScreen.kt
@@ -18,51 +18,44 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.hihihihi.presentation.designsystem.components.Medi14Text
 import com.hihihihi.presentation.designsystem.components.Semi16Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
-import com.hihihihi.presentation.navigation.NavigationRoute
 import com.hihihihi.presentation.ui.mypage.component.MyPageCalenderSection
 import com.hihihihi.presentation.ui.mypage.component.MyPageMenuSection
 import com.hihihihi.presentation.ui.mypage.component.MyPageUserProfileCard
 import com.hihihihi.presentation.ui.mypage.component.NicknameChangeDialog
 import com.hihihihi.presentation.utils.formatSecondsToReadableTimeWithoutSecond
-import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyPageScreen(
-    navController: NavHostController,
+    onNavigateToLogin: () -> Unit,
+    onNavigateToWithdraw: (String) -> Unit,
     viewModel: MypageViewModel = hiltViewModel()
 ) {
     val colors = GureumTheme.colors
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
-    var showNicknameDialog by rememberSaveable { mutableStateOf(false) } // 다이얼로그 상태
-    var showLogoutDialog by rememberSaveable { mutableStateOf(false) } // 다이얼로그 상태
-
-    //로그아웃 이벤트 수집 -> 로그인 화면으로 이동
-    LaunchedEffect(Unit) {
-        viewModel.logoutEvent.collectLatest {
-            navController.navigate(NavigationRoute.Login.route) {
-                popUpTo(navController.graph.id) {
-                    inclusive = true
-                    saveState = false
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.effect.collect { effect ->
+                when (effect) {
+                    MypageEffect.NavigateToLogin -> onNavigateToLogin()
+                    is MypageEffect.NavigateToWithdraw -> onNavigateToWithdraw(effect.userName)
                 }
-                launchSingleTop = true
-                restoreState = false
             }
         }
     }
@@ -112,7 +105,6 @@ fun MyPageScreen(
                 val timeText = remember(data.totalReadMinutes) {
                     formatSecondsToReadableTimeWithoutSecond(data.totalReadMinutes * 60)
                 }
-                //프로필 카드 ( 연필 아이콘 클릭 -> 다이얼로그 오픈)
                 MyPageUserProfileCard(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     title = "안녕하세요!",
@@ -122,7 +114,7 @@ fun MyPageScreen(
                     totalPages = "${data.totalPages}쪽",
                     totalBooks = "${data.totalBooks}권",
                     totalTime = timeText,
-                    onEditNicknameClick = { showNicknameDialog = true }
+                    onEditNicknameClick = viewModel::onNicknameChangeClick
                 )
             }
         }
@@ -139,58 +131,50 @@ fun MyPageScreen(
         )
 
         MyPageMenuSection(
-            onLogoutClick = { showLogoutDialog = true },
-            onWithDrawClick = {
-                navController.navigate(
-                    NavigationRoute.Withdraw.createRoute(
-                        state.myPageData?.user?.nickname ?: ""
+            onLogoutClick = viewModel::onLogoutClick,
+            onWithDrawClick = viewModel::onWithdrawClick
+        )
+    }
+
+    when (state.dialogState) {
+        MyPageDialogState.None -> Unit
+
+        MyPageDialogState.NicknameChange -> {
+            NicknameChangeDialog(
+                currentNickname = state.myPageData?.user?.nickname ?: "",
+                onDismiss = viewModel::dismissDialog,
+                onSave = { new ->
+                    viewModel.changeNickname(new)
+                    viewModel.dismissDialog()
+                }
+            )
+        }
+
+        MyPageDialogState.Logout -> {
+            AlertDialog(
+                onDismissRequest = viewModel::dismissDialog,
+                title = { Semi16Text("로그아웃") },
+                text = { Medi14Text("정말 로그아웃 하실건가요?") },
+                containerColor = GureumTheme.colors.card,
+                confirmButton = {
+                    Medi14Text(
+                        text = "로그아웃",
+                        color = GureumTheme.colors.systemRed,
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .clickable { viewModel.logout() }
                     )
-                )
-            }
-        )
-    }
-
-    //닉네임 변경 다이얼로그
-    if (showNicknameDialog) {
-        NicknameChangeDialog(
-            currentNickname = state.myPageData?.user?.nickname ?: "",
-            onDismiss = { showNicknameDialog = false },
-            onSave = { new ->
-                viewModel.changeNickname(new)
-                showNicknameDialog = false
-            }
-        )
-    }
-
-    if (showLogoutDialog) {
-        AlertDialog(
-            onDismissRequest = { showLogoutDialog = false },
-            title = { Semi16Text("로그아웃") },
-            text = { Medi14Text("정말 로그아웃 하실건가요?") },
-            containerColor = GureumTheme.colors.card,
-            confirmButton = {
-                Medi14Text(
-                    text = "로그아웃",
-                    color = GureumTheme.colors.systemRed,
-                    modifier = Modifier
-                        .padding(8.dp)
-                        .clickable {
-                            viewModel.logout()
-                            showLogoutDialog = false
-                        }
-                )
-            },
-            dismissButton = {
-                Medi14Text(
-                    text = "취소",
-                    color = GureumTheme.colors.gray500,
-                    modifier = Modifier
-                        .padding(8.dp)
-                        .clickable {
-                            showLogoutDialog = false
-                        }
-                )
-            }
-        )
+                },
+                dismissButton = {
+                    Medi14Text(
+                        text = "취소",
+                        color = GureumTheme.colors.gray500,
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .clickable { viewModel.dismissDialog() }
+                    )
+                }
+            )
+        }
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,7 +48,7 @@ fun MyPageScreen(
     viewModel: MypageViewModel = hiltViewModel()
 ) {
     val colors = GureumTheme.colors
-    val state by viewModel.uiState.collectAsState()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     var showNicknameDialog by rememberSaveable { mutableStateOf(false) } // 다이얼로그 상태
     var showLogoutDialog by rememberSaveable { mutableStateOf(false) } // 다이얼로그 상태

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageScreen.kt
@@ -43,7 +43,7 @@ import com.hihihihi.presentation.utils.formatSecondsToReadableTimeWithoutSecond
 fun MyPageScreen(
     onNavigateToLogin: () -> Unit,
     onNavigateToWithdraw: (String) -> Unit,
-    viewModel: MypageViewModel = hiltViewModel()
+    viewModel: MypageViewModel = hiltViewModel(),
 ) {
     val colors = GureumTheme.colors
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -64,7 +64,7 @@ fun MyPageScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(color = colors.background)
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(rememberScrollState()),
     ) {
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -73,7 +73,7 @@ fun MyPageScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = 32.dp),
-                contentAlignment = Alignment.Center
+                contentAlignment = Alignment.Center,
             ) {
                 CircularProgressIndicator()
             }
@@ -82,12 +82,12 @@ fun MyPageScreen(
                 Column(
                     modifier = Modifier.fillMaxSize(),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
+                    verticalArrangement = Arrangement.Center,
                 ) {
                     Semi16Text(
                         text = "사용자 정보를 불러오는데 실패했어요!",
                         color = GureumTheme.colors.gray600,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))
@@ -95,44 +95,44 @@ fun MyPageScreen(
                     Medi14Text(
                         text = "잠시 후 다시 시도해주세요",
                         color = GureumTheme.colors.gray500,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
                 }
             }
 
-            state.myPageData != null -> {
-                val data = state.myPageData!!
+            state.myPageUiModel != null -> {
+                val data = state.myPageUiModel!!
                 val timeText = remember(data.totalReadMinutes) {
                     formatSecondsToReadableTimeWithoutSecond(data.totalReadMinutes * 60)
                 }
                 MyPageUserProfileCard(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     title = "안녕하세요!",
-                    badge = data.user?.appellation?.ifBlank { "칭호 없음" } ?: "칭호 없음",
-                    nickname = "${data.user?.nickname?.ifBlank { "닉네임 없음" } ?: "닉네임 없음"}님",
-                    provider = data.user?.provider ?: "",
+                    badge = data.appellation?.ifBlank { "칭호 없음" } ?: "칭호 없음",
+                    nickname = "${data.nickname?.ifBlank { "닉네임 없음" } ?: "닉네임 없음"}님",
+                    provider = data.provider ?: "",
                     totalPages = "${data.totalPages}쪽",
                     totalBooks = "${data.totalBooks}권",
                     totalTime = timeText,
-                    onEditNicknameClick = viewModel::onNicknameChangeClick
+                    onEditNicknameClick = viewModel::onNicknameChangeClick,
                 )
             }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        MyPageCalenderSection(stats = state.myPageData?.readingStats ?: emptyMap())
+        MyPageCalenderSection(stats = state.myPageUiModel?.readingStats ?: emptyMap())
 
         Spacer(modifier = Modifier.height(28.dp))
 
         Divider(
             thickness = 8.dp,
-            color = colors.background10
+            color = colors.background10,
         )
 
         MyPageMenuSection(
             onLogoutClick = viewModel::onLogoutClick,
-            onWithDrawClick = viewModel::onWithdrawClick
+            onWithDrawClick = viewModel::onWithdrawClick,
         )
     }
 
@@ -141,12 +141,12 @@ fun MyPageScreen(
 
         MyPageDialogState.NicknameChange -> {
             NicknameChangeDialog(
-                currentNickname = state.myPageData?.user?.nickname ?: "",
+                currentNickname = state.myPageUiModel?.nickname ?: "",
                 onDismiss = viewModel::dismissDialog,
                 onSave = { new ->
                     viewModel.changeNickname(new)
                     viewModel.dismissDialog()
-                }
+                },
             )
         }
 
@@ -162,7 +162,7 @@ fun MyPageScreen(
                         color = GureumTheme.colors.systemRed,
                         modifier = Modifier
                             .padding(8.dp)
-                            .clickable { viewModel.logout() }
+                            .clickable { viewModel.logout() },
                     )
                 },
                 dismissButton = {
@@ -171,9 +171,9 @@ fun MyPageScreen(
                         color = GureumTheme.colors.gray500,
                         modifier = Modifier
                             .padding(8.dp)
-                            .clickable { viewModel.dismissDialog() }
+                            .clickable { viewModel.dismissDialog() },
                     )
-                }
+                },
             )
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageUiState.kt
@@ -1,10 +1,10 @@
 package com.hihihihi.presentation.ui.mypage
 
-import com.hihihihi.domain.usecase.user.MyPageData
+import com.hihihihi.presentation.ui.model.MyPageUiModel
 
 data class MyPageUiState(
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
-    val myPageData: MyPageData? = null,
-    val dialogState: MyPageDialogState = MyPageDialogState.None
+    val myPageUiModel: MyPageUiModel? = null,
+    val dialogState: MyPageDialogState = MyPageDialogState.None,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MyPageUiState.kt
@@ -5,5 +5,6 @@ import com.hihihihi.domain.usecase.user.MyPageData
 data class MyPageUiState(
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
-    val myPageData: MyPageData? = null
+    val myPageData: MyPageData? = null,
+    val dialogState: MyPageDialogState = MyPageDialogState.None
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MypageViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MypageViewModel.kt
@@ -10,13 +10,13 @@ import com.hihihihi.domain.usecase.user.GetThemeFlowUseCase
 import com.hihihihi.domain.usecase.user.SetThemeUseCase
 import com.hihihihi.domain.usecase.user.UpdateNicknameUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -24,38 +24,30 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MypageViewModel @Inject constructor(
-    private val setThemeUseCase: SetThemeUseCase,                   // 다크모드 저장용 Usecase
+    private val setThemeUseCase: SetThemeUseCase,
     private val getMyPageDataUseCase: GetMyPageDataUseCase,
-//    private val getDailyReadPagesUseCase: GetDailyReadPagesUseCase, // 잔디
-//    private val getUserUseCase: GetUserUseCase,                     // 사용자 정보 조회
-    private val updateNicknameUseCase: UpdateNicknameUseCase,       // 닉네임 변경
-//    private val getUserBooksUseCase: GetUserBooksUseCase,           //총 권수 계산용
+    private val updateNicknameUseCase: UpdateNicknameUseCase,
     getTheme: GetThemeFlowUseCase,
     private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
     private val logoutUseCase: LogoutUseCase
 ) : ViewModel() {
 
-    // FirebaseAuth로 현재 uid 참조
     private val currentUid: String?
         get() = getCurrentUserIdUseCase()
 
-    //DataStore 에서 다크모드 여부를 Flow 로 받아오는 StateFlow 형태로 보관
     val theme = getTheme().stateIn(viewModelScope, SharingStarted.Lazily, GureumThemeType.DARK)
 
-    //스위치 클릭 시 호출
     fun toggleTheme(theme: GureumThemeType) {
         viewModelScope.launch {
-            setThemeUseCase(theme) //선택된 모드 상태를 저장
+            setThemeUseCase(theme)
         }
     }
 
-    // 마이페이지 사용자 정보
     private val _uiState = MutableStateFlow(MyPageUiState())
     val uiState: StateFlow<MyPageUiState> = _uiState
 
-    //로그아웃 이벤트
-    private val _logoutEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val logoutEvent: SharedFlow<Unit> = _logoutEvent.asSharedFlow()
+    private val _effect = Channel<MypageEffect>(Channel.BUFFERED)
+    val effect: Flow<MypageEffect> = _effect.receiveAsFlow()
 
     init {
         viewModelScope.launch {
@@ -70,7 +62,6 @@ class MypageViewModel @Inject constructor(
                         _uiState.update {
                             it.copy(myPageData = myPageData, isLoading = false)
                         }
-
                     }
             } catch (e: Exception) {
                 _uiState.update {
@@ -80,7 +71,6 @@ class MypageViewModel @Inject constructor(
         }
     }
 
-    //닉네임 변경, 현재 uid 기준으로
     fun changeNickname(newNickname: String) = viewModelScope.launch {
         val uid = currentUid ?: return@launch
         runCatching { updateNicknameUseCase(uid, newNickname) }
@@ -88,16 +78,42 @@ class MypageViewModel @Inject constructor(
             .onFailure { e -> _uiState.update { it.copy(errorMessage = e.message) } }
     }
 
-
-    //로그아웃: 세션 종료 후 이벤트 발생
     fun logout() = viewModelScope.launch {
         runCatching {
             logoutUseCase()
         }
             .onSuccess {
                 _uiState.value = MyPageUiState(isLoading = false)
-                _logoutEvent.tryEmit(Unit)
+                _effect.send(MypageEffect.NavigateToLogin)
             }
             .onFailure { e -> _uiState.update { it.copy(errorMessage = e.message) } }
     }
+
+    fun onLogoutClick() {
+        _uiState.update { it.copy(dialogState = MyPageDialogState.Logout) }
+    }
+
+    fun onNicknameChangeClick() {
+        _uiState.update { it.copy(dialogState = MyPageDialogState.NicknameChange) }
+    }
+
+    fun dismissDialog() {
+        _uiState.update { it.copy(dialogState = MyPageDialogState.None) }
+    }
+
+    fun onWithdrawClick() {
+        val userName = _uiState.value.myPageData?.user?.nickname ?: ""
+        viewModelScope.launch { _effect.send(MypageEffect.NavigateToWithdraw(userName)) }
+    }
+}
+
+sealed interface MyPageDialogState {
+    data object None : MyPageDialogState
+    data object Logout : MyPageDialogState
+    data object NicknameChange : MyPageDialogState
+}
+
+sealed interface MypageEffect {
+    data object NavigateToLogin : MypageEffect
+    data class NavigateToWithdraw(val userName: String) : MypageEffect
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MypageViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MypageViewModel.kt
@@ -103,7 +103,11 @@ class MypageViewModel @Inject constructor(
     }
 
     fun onWithdrawClick() {
-        val userName = _uiState.value.myPageUiModel?.nickname ?: ""
+        val userName = _uiState.value.myPageUiModel?.nickname
+        if (userName.isNullOrBlank()) {
+            _uiState.update { it.copy(errorMessage = "사용자 정보를 불러오는 중입니다. 잠시 후 다시 시도해 주세요.") }
+            return
+        }
         viewModelScope.launch { _effect.send(MypageEffect.NavigateToWithdraw(userName)) }
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MypageViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/MypageViewModel.kt
@@ -9,6 +9,7 @@ import com.hihihihi.domain.usecase.user.GetMyPageDataUseCase
 import com.hihihihi.domain.usecase.user.GetThemeFlowUseCase
 import com.hihihihi.domain.usecase.user.SetThemeUseCase
 import com.hihihihi.domain.usecase.user.UpdateNicknameUseCase
+import com.hihihihi.presentation.ui.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -29,7 +30,7 @@ class MypageViewModel @Inject constructor(
     private val updateNicknameUseCase: UpdateNicknameUseCase,
     getTheme: GetThemeFlowUseCase,
     private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
-    private val logoutUseCase: LogoutUseCase
+    private val logoutUseCase: LogoutUseCase,
 ) : ViewModel() {
 
     private val currentUid: String?
@@ -60,7 +61,7 @@ class MypageViewModel @Inject constructor(
                     }
                     .collect { myPageData ->
                         _uiState.update {
-                            it.copy(myPageData = myPageData, isLoading = false)
+                            it.copy(myPageUiModel = myPageData.toUiModel(), isLoading = false)
                         }
                     }
             } catch (e: Exception) {
@@ -83,7 +84,7 @@ class MypageViewModel @Inject constructor(
             logoutUseCase()
         }
             .onSuccess {
-                _uiState.value = MyPageUiState(isLoading = false)
+                _uiState.value = MyPageUiState(isLoading = false, myPageUiModel = null)
                 _effect.send(MypageEffect.NavigateToLogin)
             }
             .onFailure { e -> _uiState.update { it.copy(errorMessage = e.message) } }
@@ -102,7 +103,7 @@ class MypageViewModel @Inject constructor(
     }
 
     fun onWithdrawClick() {
-        val userName = _uiState.value.myPageData?.user?.nickname ?: ""
+        val userName = _uiState.value.myPageUiModel?.nickname ?: ""
         viewModelScope.launch { _effect.send(MypageEffect.NavigateToWithdraw(userName)) }
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/component/MyPageMenuSection.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/component/MyPageMenuSection.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -26,7 +26,7 @@ fun MyPageMenuSection(
     onLogoutClick: () -> Unit,
     onWithDrawClick: () -> Unit
 ) {
-    val theme by viewModel.theme.collectAsState()
+    val theme by viewModel.theme.collectAsStateWithLifecycle()
     val colors = GureumTheme.colors
     val context = LocalContext.current
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/component/MyPageMenuSection.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/mypage/component/MyPageMenuSection.kt
@@ -7,26 +7,22 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.hihihihi.domain.model.GureumThemeType
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
-import com.hihihihi.presentation.ui.mypage.MypageViewModel
 import com.hihihihi.presentation.utils.openAppOnPlayStore
 import com.hihihihi.presentation.utils.openSupportEmail
 
 @Composable
 fun MyPageMenuSection(
-    viewModel: MypageViewModel = hiltViewModel(),
+    theme: GureumThemeType,
+    onThemeToggle: (GureumThemeType) -> Unit,
     onLogoutClick: () -> Unit,
     onWithDrawClick: () -> Unit
 ) {
-    val theme by viewModel.theme.collectAsStateWithLifecycle()
     val colors = GureumTheme.colors
     val context = LocalContext.current
 
@@ -62,7 +58,7 @@ fun MyPageMenuSection(
             showSwitch = true,
             showArrow = false,
             switchChecked = (theme == GureumThemeType.DARK),
-            onSwitchToggle = { viewModel.toggleTheme(it) }
+            onSwitchToggle = { onThemeToggle(it) }
         ) { }
 
         MyPageMenuSettingItem(

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/nonetwork/NoNetworkScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/nonetwork/NoNetworkScreen.kt
@@ -1,5 +1,6 @@
 package com.hihihihi.presentation.ui.nonetwork
 
+import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,33 +18,37 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hihihihi.presentation.designsystem.components.Medi16Text
 import com.hihihihi.presentation.designsystem.components.Semi16Text
 import com.hihihihi.presentation.designsystem.components.Semi24Text
+import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 
 @Composable
 fun NoNetworkScreen(
     onRefresh: () -> Unit,
-    onExit: () -> Unit
+    onExit: () -> Unit,
 ) {
-    BackHandler {
-        onExit()
-    }
+    BackHandler { onExit() }
+    NoNetworkContent(onRefresh = onRefresh)
+}
 
+@Composable
+private fun NoNetworkContent(onRefresh: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Center,
     ) {
         Icon(
             Icons.Default.CloudOff,
             contentDescription = null,
             modifier = Modifier.size(60.dp),
-            tint = GureumTheme.colors.gray400
+            tint = GureumTheme.colors.gray400,
         )
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -51,7 +56,7 @@ fun NoNetworkScreen(
         Semi24Text(
             "인터넷 연결이 끊어졌어요",
             color = GureumTheme.colors.gray700,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
 
         Spacer(modifier = Modifier.height(12.dp))
@@ -59,7 +64,7 @@ fun NoNetworkScreen(
         Medi16Text(
             "Wi-Fi나 모바일 데이터 연결을\n확인해 주세요",
             color = GureumTheme.colors.gray600,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
 
         Spacer(modifier = Modifier.height(40.dp))
@@ -68,14 +73,19 @@ fun NoNetworkScreen(
             onClick = onRefresh,
             modifier = Modifier.padding(16.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = GureumTheme.colors.primary
-            )
+                containerColor = GureumTheme.colors.primary,
+            ),
         ) {
-            Semi16Text(
-                "새로 고침",
-                color = GureumTheme.colors.white
-            )
+            Semi16Text("새로 고침", color = GureumTheme.colors.white)
         }
+    }
+}
 
+@Preview(name = "Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun NoNetworkPreview() {
+    GureumPageTheme {
+        NoNetworkContent(onRefresh = {})
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingScreen.kt
@@ -4,7 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -28,7 +28,7 @@ fun OnBoardingScreen(
     navController: NavHostController,
     viewModel: OnBoardingViewModel = hiltViewModel(),
 ) {
-    val steps by viewModel.steps.collectAsState()
+    val steps by viewModel.steps.collectAsStateWithLifecycle()
     GureumPageTheme(darkTheme = true) {
         OnboardingContents(
             steps = steps,

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingScreen.kt
@@ -1,11 +1,13 @@
 package com.hihihihi.presentation.ui.onboarding
 
+import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.domain.model.GureumThemeType
@@ -30,9 +32,11 @@ fun OnBoardingScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     GureumPageTheme(darkTheme = true) {
-        OnboardingContents(
+        OnBoardingContent(
             steps = viewModel.steps,
-            uiState = uiState,
+            nickname = uiState.nickname,
+            selectedPurposes = uiState.selectedPurposes,
+            theme = uiState.theme,
             onNicknameChange = viewModel::updateNickname,
             onTogglePurpose = viewModel::togglePurpose,
             onFeaturePageChanged = viewModel::featurePageChanged,
@@ -46,9 +50,11 @@ fun OnBoardingScreen(
 }
 
 @Composable
-private fun OnboardingContents(
+private fun OnBoardingContent(
     steps: List<OnboardingStep>,
-    uiState: OnBoardingUiState,
+    nickname: String,
+    selectedPurposes: List<String>,
+    theme: GureumThemeType?,
     onNicknameChange: (String) -> Unit,
     onTogglePurpose: (String) -> Unit,
     onFeaturePageChanged: (Int, Int) -> Unit,
@@ -89,12 +95,12 @@ private fun OnboardingContents(
             when (step) {
                 OnboardingStep.Welcome -> WelcomePage()
                 OnboardingStep.Nickname -> NicknamePage(
-                    nickname = uiState.nickname,
+                    nickname = nickname,
                     onNicknameChange = onNicknameChange,
                 )
 
                 OnboardingStep.Purpose -> PurposePage(
-                    selectedPurposes = uiState.selectedPurposes,
+                    selectedPurposes = selectedPurposes,
                     onTogglePurpose = onTogglePurpose,
                 )
 
@@ -103,7 +109,7 @@ private fun OnboardingContents(
                 )
 
                 OnboardingStep.Theme -> ThemePage(
-                    selectedTheme = uiState.theme,
+                    selectedTheme = theme,
                     onSelectTheme = onSelectTheme,
                 )
 
@@ -136,4 +142,26 @@ private fun OnboardingContents(
 private fun computeProgress(pagerState: PagerState): Float {
     val position = pagerState.currentPage + pagerState.currentPageOffsetFraction
     return (position / (pagerState.pageCount - 1)).coerceIn(0f, 1f)
+}
+
+@Preview(name = "Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun OnBoardingPreview() {
+    GureumPageTheme(darkTheme = true) {
+        OnBoardingContent(
+            steps = listOf(OnboardingStep.Welcome, OnboardingStep.Nickname, OnboardingStep.Purpose, OnboardingStep.Feature, OnboardingStep.Theme, OnboardingStep.Finish),
+            nickname = "",
+            selectedPurposes = emptyList(),
+            theme = null,
+            onNicknameChange = {},
+            onTogglePurpose = {},
+            onFeaturePageChanged = { _, _ -> },
+            onSelectTheme = {},
+            isNextEnabled = { true },
+            onNavigateBack = {},
+            onSave = {},
+            onFinish = {},
+        )
+    }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingScreen.kt
@@ -4,13 +4,11 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
-import com.hihihihi.presentation.navigation.NavigationRoute
 import com.hihihihi.presentation.ui.onboarding.components.OnboardingBottomContents
 import com.hihihihi.presentation.ui.onboarding.components.OnboardingScaffold
 import com.hihihihi.presentation.ui.onboarding.components.OnboardingTopContents
@@ -25,7 +23,8 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun OnBoardingScreen(
-    navController: NavHostController,
+    onNavigateToHome: () -> Unit,
+    onNavigateBack: () -> Unit,
     viewModel: OnBoardingViewModel = hiltViewModel(),
 ) {
     val steps by viewModel.steps.collectAsStateWithLifecycle()
@@ -33,14 +32,9 @@ fun OnBoardingScreen(
         OnboardingContents(
             steps = steps,
             viewModel = viewModel,
-            navController = navController,
+            onNavigateBack = onNavigateBack,
             onSave = { viewModel.saveOnboardingComplete() },
-            onFinish = {
-                navController.navigate(NavigationRoute.Home.route) {
-                    popUpTo(NavigationRoute.OnBoarding.route) { inclusive = true }
-                    launchSingleTop = true
-                }
-            },
+            onFinish = onNavigateToHome,
         )
     }
 }
@@ -49,7 +43,7 @@ fun OnBoardingScreen(
 private fun OnboardingContents(
     steps: List<OnboardingStep>,
     viewModel: OnBoardingViewModel,
-    navController: NavHostController,
+    onNavigateBack: () -> Unit,
     onSave: () -> Unit,
     onFinish: () -> Unit
 ) {
@@ -62,7 +56,7 @@ private fun OnboardingContents(
         if (pagerState.currentPage > 0) {
             scope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) }
         } else {
-            navController.popBackStack()
+            onNavigateBack()
         }
     }
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hihihihi.domain.model.GureumThemeType
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.ui.onboarding.components.OnboardingBottomContents
 import com.hihihihi.presentation.ui.onboarding.components.OnboardingScaffold
@@ -27,11 +28,16 @@ fun OnBoardingScreen(
     onNavigateBack: () -> Unit,
     viewModel: OnBoardingViewModel = hiltViewModel(),
 ) {
-    val steps by viewModel.steps.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     GureumPageTheme(darkTheme = true) {
         OnboardingContents(
-            steps = steps,
-            viewModel = viewModel,
+            steps = viewModel.steps,
+            uiState = uiState,
+            onNicknameChange = viewModel::updateNickname,
+            onTogglePurpose = viewModel::togglePurpose,
+            onFeaturePageChanged = viewModel::featurePageChanged,
+            onSelectTheme = viewModel::selectTheme,
+            isNextEnabled = viewModel::isNextEnabled,
             onNavigateBack = onNavigateBack,
             onSave = { viewModel.saveOnboardingComplete() },
             onFinish = onNavigateToHome,
@@ -42,10 +48,15 @@ fun OnBoardingScreen(
 @Composable
 private fun OnboardingContents(
     steps: List<OnboardingStep>,
-    viewModel: OnBoardingViewModel,
+    uiState: OnBoardingUiState,
+    onNicknameChange: (String) -> Unit,
+    onTogglePurpose: (String) -> Unit,
+    onFeaturePageChanged: (Int, Int) -> Unit,
+    onSelectTheme: (GureumThemeType) -> Unit,
+    isNextEnabled: (OnboardingStep) -> Boolean,
     onNavigateBack: () -> Unit,
     onSave: () -> Unit,
-    onFinish: () -> Unit
+    onFinish: () -> Unit,
 ) {
     val pagerState = rememberPagerState { steps.size }
     val scope = rememberCoroutineScope()
@@ -62,7 +73,7 @@ private fun OnboardingContents(
 
     OnboardingScaffold(
         pagerState = pagerState,
-        topContent = { page, step ->
+        topContent = { _, step ->
             if (step !is OnboardingStep.Welcome && step !is OnboardingStep.Finish) {
                 OnboardingTopContents(
                     onBack = {
@@ -70,18 +81,33 @@ private fun OnboardingContents(
                             if (pagerState.currentPage > 0) pagerState.animateScrollToPage(pagerState.currentPage - 1)
                         }
                     },
-                    progress = computeProgress(pagerState)
+                    progress = computeProgress(pagerState),
                 )
             }
         },
-        mainContent = { page, step ->
+        mainContent = { _, step ->
             when (step) {
                 OnboardingStep.Welcome -> WelcomePage()
-                OnboardingStep.Nickname -> NicknamePage(viewModel = viewModel)
-                OnboardingStep.Purpose -> PurposePage(viewModel = viewModel)
-                OnboardingStep.Feature -> FeaturePage(viewModel = viewModel)
-                OnboardingStep.Theme -> ThemePage(viewModel = viewModel)
-                OnboardingStep.Finish -> FinishPage(viewModel = viewModel)
+                OnboardingStep.Nickname -> NicknamePage(
+                    nickname = uiState.nickname,
+                    onNicknameChange = onNicknameChange,
+                )
+
+                OnboardingStep.Purpose -> PurposePage(
+                    selectedPurposes = uiState.selectedPurposes,
+                    onTogglePurpose = onTogglePurpose,
+                )
+
+                OnboardingStep.Feature -> FeaturePage(
+                    onFeaturePageChanged = onFeaturePageChanged,
+                )
+
+                OnboardingStep.Theme -> ThemePage(
+                    selectedTheme = uiState.theme,
+                    onSelectTheme = onSelectTheme,
+                )
+
+                OnboardingStep.Finish -> FinishPage()
             }
         },
         bottomContent = { page, step ->
@@ -93,7 +119,7 @@ private fun OnboardingContents(
                     OnboardingStep.Feature -> "옆으로 밀어 구름한장의 기능을 확인해보세요!"
                     else -> ""
                 },
-                isNextEnabled = viewModel.isNextEnabled(currentStep),
+                isNextEnabled = isNextEnabled(currentStep),
                 onNext = {
                     scope.launch {
                         if (step == OnboardingStep.Theme) onSave()

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingUiState.kt
@@ -1,7 +1,9 @@
 package com.hihihihi.presentation.ui.onboarding
 
+import androidx.compose.runtime.Immutable
 import com.hihihihi.domain.model.GureumThemeType
 
+@Immutable
 data class OnBoardingUiState(
     val nickname: String = "",
     val selectedPurposes: List<String> = emptyList(),

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingUiState.kt
@@ -1,0 +1,11 @@
+package com.hihihihi.presentation.ui.onboarding
+
+import com.hihihihi.domain.model.GureumThemeType
+
+data class OnBoardingUiState(
+    val nickname: String = "",
+    val selectedPurposes: List<String> = emptyList(),
+    val currentInnerPage: Int = 0,
+    val featurePageCount: Int = 0,
+    val theme: GureumThemeType? = null,
+)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingViewModel.kt
@@ -1,10 +1,5 @@
 package com.hihihihi.presentation.ui.onboarding
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hihihihi.domain.model.GureumThemeType
@@ -17,6 +12,8 @@ import com.hihihihi.presentation.utils.NicknameValidator.validateNickname
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -27,66 +24,59 @@ class OnBoardingViewModel @Inject constructor(
     private val setThemeUseCase: SetThemeUseCase,
     private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
 ) : ViewModel() {
-    private val _steps = MutableStateFlow<List<OnboardingStep>>(emptyList())
-    val steps: StateFlow<List<OnboardingStep>> = _steps
 
-    val selectedPurposes = mutableStateListOf<String>()
+    private val _uiState = MutableStateFlow(OnBoardingUiState())
+    val uiState: StateFlow<OnBoardingUiState> = _uiState.asStateFlow()
 
-    private var featurePageCount by mutableIntStateOf(0)
-    var currentInnerPage by mutableIntStateOf(0)
-        private set
-    var nickname by mutableStateOf("")
-        private set
-    var theme by mutableStateOf<GureumThemeType?>(null)
-        private set
-
-    init {
-        _steps.value = listOf(
-            OnboardingStep.Welcome,
-            OnboardingStep.Nickname,
-            OnboardingStep.Purpose,
-            OnboardingStep.Feature,
-            OnboardingStep.Theme,
-            OnboardingStep.Finish
-        )
-    }
+    val steps: List<OnboardingStep> = listOf(
+        OnboardingStep.Welcome,
+        OnboardingStep.Nickname,
+        OnboardingStep.Purpose,
+        OnboardingStep.Feature,
+        OnboardingStep.Theme,
+        OnboardingStep.Finish,
+    )
 
     fun updateNickname(nickname: String) {
-        this.nickname = nickname
+        _uiState.update { it.copy(nickname = nickname) }
     }
 
     fun saveNickname() {
         val userId: String? = getCurrentUserIdUseCase()
-        viewModelScope.launch { setNicknameUseCase(userId!!, nickname.trim()) }
+        viewModelScope.launch { setNicknameUseCase(userId!!, _uiState.value.nickname.trim()) }
     }
 
-    // TODO: 추후 사용자 앱 설치 목적 파악을 위해 DB 테이블 만들기 고려
     fun togglePurpose(purpose: String) {
-        if (selectedPurposes.contains(purpose)) selectedPurposes.remove(purpose)
-        else selectedPurposes.add(purpose)
+        _uiState.update { state ->
+            val current = state.selectedPurposes.toMutableList()
+            if (current.contains(purpose)) current.remove(purpose) else current.add(purpose)
+            state.copy(selectedPurposes = current)
+        }
     }
 
     fun featurePageChanged(page: Int, count: Int) {
-        currentInnerPage = page
-        featurePageCount = count - 1
+        _uiState.update { it.copy(currentInnerPage = page, featurePageCount = count - 1) }
     }
 
-    fun isNextEnabled(step: OnboardingStep): Boolean = when (step) {
-        OnboardingStep.Nickname -> nickname.validateNickname()
-        OnboardingStep.Purpose -> selectedPurposes.isNotEmpty()
-        OnboardingStep.Feature -> currentInnerPage >= featurePageCount
-        OnboardingStep.Theme -> theme != null
-        else -> true
+    fun isNextEnabled(step: OnboardingStep): Boolean {
+        val state = _uiState.value
+        return when (step) {
+            OnboardingStep.Nickname -> state.nickname.validateNickname()
+            OnboardingStep.Purpose -> state.selectedPurposes.isNotEmpty()
+            OnboardingStep.Feature -> state.currentInnerPage >= state.featurePageCount
+            OnboardingStep.Theme -> state.theme != null
+            else -> true
+        }
     }
 
     fun selectTheme(theme: GureumThemeType) {
-        this@OnBoardingViewModel.theme = theme
+        _uiState.update { it.copy(theme = theme) }
     }
 
     fun saveOnboardingComplete() {
         viewModelScope.launch {
             val uid = getCurrentUserIdUseCase() ?: return@launch
-            theme?.let { setThemeUseCase(it) }
+            _uiState.value.theme?.let { setThemeUseCase(it) }
             saveNickname()
             setOnboardingCompleteUseCase(uid, true)
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/OnBoardingViewModel.kt
@@ -42,8 +42,8 @@ class OnBoardingViewModel @Inject constructor(
     }
 
     fun saveNickname() {
-        val userId: String? = getCurrentUserIdUseCase()
-        viewModelScope.launch { setNicknameUseCase(userId!!, _uiState.value.nickname.trim()) }
+        val userId = getCurrentUserIdUseCase() ?: return
+        viewModelScope.launch { setNicknameUseCase(userId, _uiState.value.nickname.trim()) }
     }
 
     fun togglePurpose(purpose: String) {
@@ -77,7 +77,7 @@ class OnBoardingViewModel @Inject constructor(
         viewModelScope.launch {
             val uid = getCurrentUserIdUseCase() ?: return@launch
             _uiState.value.theme?.let { setThemeUseCase(it) }
-            saveNickname()
+            setNicknameUseCase(uid, _uiState.value.nickname.trim())
             setOnboardingCompleteUseCase(uid, true)
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/FeaturePage.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/FeaturePage.kt
@@ -42,15 +42,14 @@ import com.hihihihi.presentation.designsystem.components.Medi14Text
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
-import com.hihihihi.presentation.ui.onboarding.OnBoardingViewModel
 import com.hihihihi.presentation.ui.onboarding.model.OnboardingFeature
 import kotlinx.coroutines.flow.distinctUntilChanged
 
-@OptIn(ExperimentalFoundationApi::class)
 @SuppressLint("UnusedBoxWithConstraintsScope")
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FeaturePage(
-    viewModel: OnBoardingViewModel
+    onFeaturePageChanged: (Int, Int) -> Unit,
 ) {
     val pagerState = rememberPagerState { featurePages.size }
 
@@ -58,32 +57,30 @@ fun FeaturePage(
         snapshotFlow { pagerState.currentPage to pagerState.pageCount }
             .distinctUntilChanged()
             .collect { (currentPage, pageCount) ->
-                viewModel.featurePageChanged(currentPage, pageCount)
+                onFeaturePageChanged(currentPage, pageCount)
             }
     }
 
     BoxWithConstraints(Modifier.fillMaxSize()) {
-        // 바텀 시스템 내비 영역 인셋
         val bottomInset = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
         val indicatorPadding = maxHeight * 0.26f - bottomInset
 
-        // 오버 스크롤 모션 삭제
         CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier.fillMaxSize(),
             ) { pageIndex ->
                 val page = featurePages[pageIndex]
 
                 Column(
                     modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Image(
                         painter = painterResource(page.gureumImage),
                         contentDescription = "OnboardingGureumImage",
-                        modifier = Modifier.size(120.dp)
+                        modifier = Modifier.size(120.dp),
                     )
                     Spacer(Modifier.height(14.dp))
                     Text(
@@ -97,7 +94,7 @@ fun FeaturePage(
                         text = page.subTitle,
                         color = GureumTheme.colors.gray500,
                         textAlign = TextAlign.Center,
-                        lineHeight = 22.sp
+                        lineHeight = 22.sp,
                     )
                     Spacer(Modifier.height(24.dp))
                     Column {
@@ -111,37 +108,30 @@ fun FeaturePage(
             }
         }
         PagerIndicator(
-            state = pagerState, modifier = Modifier
+            state = pagerState,
+            modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = indicatorPadding)
+                .padding(bottom = indicatorPadding),
         )
     }
 }
 
 @Composable
 private fun DotWithText(detail: String) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically
-    ) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
         Box(
             modifier = Modifier
                 .size(8.dp)
                 .clip(CircleShape)
-                .background(GureumTheme.colors.primary)
+                .background(GureumTheme.colors.primary),
         )
         Spacer(Modifier.width(8.dp))
-        Medi14Text(
-            text = detail,
-            color = GureumTheme.colors.gray400
-        )
+        Medi14Text(text = detail, color = GureumTheme.colors.gray400)
     }
 }
 
 @Composable
-private fun PagerIndicator(
-    state: PagerState,
-    modifier: Modifier = Modifier,
-) {
+private fun PagerIndicator(state: PagerState, modifier: Modifier = Modifier) {
     val colors = GureumTheme.colors
     Row(
         modifier = modifier,
@@ -155,39 +145,33 @@ private fun PagerIndicator(
                 modifier = Modifier
                     .size(if (currentPage) 10.dp else 8.dp)
                     .clip(CircleShape)
-                    .background(color)
+                    .background(color),
             )
-            if (index < state.pageCount - 1) {
-                Spacer(Modifier.width(8.dp))
-            }
+            if (index < state.pageCount - 1) Spacer(Modifier.width(8.dp))
         }
     }
 }
 
 private val featurePages = listOf(
     OnboardingFeature(
-        R.drawable.ic_cloud_library,
-        "나만의 디지털 서재",
+        R.drawable.ic_cloud_library, "나만의 디지털 서재",
         "읽은 책, 읽는 중, 완독한 책을\n체계적으로 관리해요",
-        listOf("책 상태별 분류 관리", "독서 진행률 추적", "책 정보와 내 필사 보기")
+        listOf("책 상태별 분류 관리", "독서 진행률 추적", "책 정보와 내 필사 보기"),
     ),
     OnboardingFeature(
-        R.drawable.ic_cloud_timer,
-        "독서 스톱워치",
+        R.drawable.ic_cloud_timer, "독서 스톱워치",
         "독서 시간을 측정하고\n꾸준한 독서 습관을 만들어보세요",
-        listOf("스톱워치로 독서 시간 측정", "일일 목표 설정", "누적 통계 제공")
+        listOf("스톱워치로 독서 시간 측정", "일일 목표 설정", "누적 통계 제공"),
     ),
     OnboardingFeature(
-        R.drawable.ic_cloud_mindmap,
-        "필사 & 마인드맵",
+        R.drawable.ic_cloud_mindmap, "필사 & 마인드맵",
         "인상 깊은 문장을 기록하거나\n인물, 정보의 관계를 마인드 맵으로 만들어요",
-        listOf("책 속 문장 필사", "자유로운 마인드맵 생성", "인물 및 줄거리 관계도")
+        listOf("책 속 문장 필사", "자유로운 마인드맵 생성", "인물 및 줄거리 관계도"),
     ),
     OnboardingFeature(
-        R.drawable.ic_cloud_statistics,
-        "독서 통계 & 분석",
+        R.drawable.ic_cloud_statistics, "독서 통계 & 분석",
         "내 독서 패턴을 분석하고\n더 나은 독서 계획을 세워봐요",
-        listOf("장르별 선호도 분석", "시간대별 독서 패턴", "월별/주간/연간 독서량 추이")
+        listOf("장르별 선호도 분석", "시간대별 독서 패턴", "월별/주간/연간 독서량 추이"),
     ),
 )
 
@@ -195,6 +179,6 @@ private val featurePages = listOf(
 @Composable
 private fun FeaturePagePreview() {
     GureumPageTheme {
-//        FeaturePage()
+        FeaturePage(onFeaturePageChanged = { _, _ -> })
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/FeaturePage.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/FeaturePage.kt
@@ -53,7 +53,7 @@ fun FeaturePage(
 ) {
     val pagerState = rememberPagerState { featurePages.size }
 
-    LaunchedEffect(pagerState.currentPage) {
+    LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.currentPage to pagerState.pageCount }
             .distinctUntilChanged()
             .collect { (currentPage, pageCount) ->

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/FinishPage.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/FinishPage.kt
@@ -1,6 +1,5 @@
 package com.hihihihi.presentation.ui.onboarding.pages
 
-import android.annotation.SuppressLint
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,49 +16,43 @@ import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
-import com.hihihihi.presentation.ui.onboarding.OnBoardingViewModel
 import com.hihihihi.presentation.ui.onboarding.components.OnBoardingMainContents
 
 @Composable
-fun FinishPage(viewModel: OnBoardingViewModel) {
-    val nickname = viewModel.nickname
+fun FinishPage() {
     val confettiComposition by rememberLottieComposition(
-        LottieCompositionSpec.Asset("confetti.json")
+        LottieCompositionSpec.Asset("confetti.json"),
     )
-
     val progress by animateLottieCompositionAsState(
         composition = confettiComposition,
-        iterations = 1, // 한 번만 재생
-        isPlaying = true    // 자동 재생
+        iterations = 1,
+        isPlaying = true,
     )
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // 기존 콘텐츠
         OnBoardingMainContents(
             titleText = "설정 완료!",
-            subTitleText = "${nickname}님의\n구름한장 여정이 시작됩니다!",
-            gureumRes = R.drawable.ic_cloud_complete
+            subTitleText = "구름한장 여정이 시작됩니다!",
+            gureumRes = R.drawable.ic_cloud_complete,
         ) {}
 
-        // Confetti 애니메이션 오버레이
         if (progress < 1f) {
             LottieAnimation(
                 composition = confettiComposition,
                 progress = { progress },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .align(Alignment.TopCenter), // 화면 위쪽
-                contentScale = ContentScale.FillWidth
+                    .align(Alignment.TopCenter),
+                contentScale = ContentScale.FillWidth,
             )
         }
     }
 }
 
-@SuppressLint("ViewModelConstructorInComposable")
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun FinishPagePreview() {
     GureumPageTheme {
-//        FinishPage(OnBoardingViewModel())
+        FinishPage()
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/NicknamePage.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/NicknamePage.kt
@@ -1,6 +1,5 @@
 package com.hihihihi.presentation.ui.onboarding.pages
 
-import android.annotation.SuppressLint
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -25,48 +24,47 @@ import com.hihihihi.presentation.designsystem.components.GureumTextField
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
-import com.hihihihi.presentation.ui.onboarding.OnBoardingViewModel
 import com.hihihihi.presentation.ui.onboarding.components.OnBoardingMainContents
 import com.hihihihi.presentation.utils.NicknameRule
 import com.hihihihi.presentation.utils.NicknameValidator
 
 @Composable
-fun NicknamePage(viewModel: OnBoardingViewModel) {
-
+fun NicknamePage(
+    nickname: String,
+    onNicknameChange: (String) -> Unit,
+) {
     OnBoardingMainContents(
         gureumRes = R.drawable.ic_cloud_question,
         titleText = "어떻게 불러드릴까요?",
-        subTitleText = "앱에서 사용할 닉네임을 설정해주세요"
+        subTitleText = "앱에서 사용할 닉네임을 설정해주세요",
     ) {
         Spacer(Modifier.height(6.dp))
         Text(
             text = "2~8자 이내로 입력해주세요",
             style = GureumTypography.bodyMedium,
-            color = GureumTheme.colors.gray400
+            color = GureumTheme.colors.gray400,
         )
         Spacer(Modifier.height(24.dp))
 
         Column(
             modifier = Modifier.padding(horizontal = 24.dp),
-            horizontalAlignment = Alignment.End
+            horizontalAlignment = Alignment.End,
         ) {
-            val rule = NicknameValidator.validate(viewModel.nickname)
+            val rule = NicknameValidator.validate(nickname)
             GureumTextField(
-                value = viewModel.nickname,
-                onValueChange = {
-                    viewModel.updateNickname(it)
-                },
+                value = nickname,
+                onValueChange = onNicknameChange,
                 hint = "닉네임을 입력해주세요",
                 textAlign = TextAlign.Center,
                 imeAction = ImeAction.Done,
                 isError = rule !is NicknameRule.Ok,
                 trailingIcon = {
-                    if (viewModel.nickname.isNotEmpty()) {
-                        IconButton(onClick = { viewModel.updateNickname("") }) {
+                    if (nickname.isNotEmpty()) {
+                        IconButton(onClick = { onNicknameChange("") }) {
                             Icon(
                                 imageVector = Icons.Outlined.Close,
                                 contentDescription = "지우기",
-                                tint = GureumTheme.colors.gray300
+                                tint = GureumTheme.colors.gray300,
                             )
                         }
                     }
@@ -76,24 +74,23 @@ fun NicknamePage(viewModel: OnBoardingViewModel) {
                     text = buildAnnotatedString {
                         pushStyle(
                             GureumTypography.titleSmall.toSpanStyle()
-                                .copy(GureumTheme.colors.gray400)
+                                .copy(GureumTheme.colors.gray400),
                         )
-                        append(viewModel.nickname.length.toString())
+                        append(nickname.length.toString())
                         append("/8")
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.End
+                    textAlign = TextAlign.End,
                 )
             }
         }
     }
 }
 
-@SuppressLint("ViewModelConstructorInComposable")
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun NicknamePagePreview() {
     GureumPageTheme {
-//        NicknamePage(OnBoardingViewModel())
+        NicknamePage(nickname = "구름이", onNicknameChange = {})
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/PurposePage.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/PurposePage.kt
@@ -8,34 +8,32 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hihihihi.presentation.R
-import com.hihihihi.presentation.ui.onboarding.OnBoardingViewModel
 import com.hihihihi.presentation.ui.onboarding.components.OnBoardingMainContents
 import com.hihihihi.presentation.ui.onboarding.components.OnboardingPurposeCard
 import com.hihihihi.presentation.ui.onboarding.model.OnboardingPurposeContents
 
 @Composable
-fun PurposePage(viewModel: OnBoardingViewModel) {
-    val selectedPurpose = viewModel.selectedPurposes
-
+fun PurposePage(
+    selectedPurposes: List<String>,
+    onTogglePurpose: (String) -> Unit,
+) {
     OnBoardingMainContents(
         titleText = "구름한장을 사용하는\n목적을 알려주세요",
         subTitleText = "한가지 이상 선택해주세요",
-        showGureum = false
+        showGureum = false,
     ) {
         Spacer(Modifier.height(20.dp))
 
         Column(
-            modifier = Modifier.padding(horizontal = 20.dp)
+            modifier = Modifier.padding(horizontal = 20.dp),
         ) {
             Column {
                 purposeContents.forEach { content ->
-                    val isChecked = selectedPurpose.contains(content.title)
+                    val isChecked = selectedPurposes.contains(content.title)
                     OnboardingPurposeCard(
                         cardItem = content,
                         checked = isChecked,
-                        onCheckedChange = {
-                            viewModel.togglePurpose(content.title)
-                        },
+                        onCheckedChange = { onTogglePurpose(content.title) },
                     )
                     Spacer(Modifier.height(10.dp))
                 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/ThemePage.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/onboarding/pages/ThemePage.kt
@@ -9,35 +9,36 @@ import androidx.compose.ui.unit.dp
 import com.hihihihi.domain.model.GureumThemeType
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
-import com.hihihihi.presentation.ui.onboarding.OnBoardingViewModel
 import com.hihihihi.presentation.ui.onboarding.components.OnBoardingMainContents
 import com.hihihihi.presentation.ui.onboarding.components.OnboardingThemeCard
 
 @Composable
-fun ThemePage(viewModel: OnBoardingViewModel) {
-    val selectedTheme = viewModel.theme
+fun ThemePage(
+    selectedTheme: GureumThemeType?,
+    onSelectTheme: (GureumThemeType) -> Unit,
+) {
     OnBoardingMainContents(
         titleText = "선호하는 테마를 선택해주세요",
         subTitleText = "언제든 설정에서 변경할 수 있어요",
-        showGureum = false
+        showGureum = false,
     ) {
         Spacer(Modifier.height(6.dp))
         Text(
             text = "독서에 집중할 수 있는 테마를 골라보세요",
             style = GureumTypography.bodyMedium,
-            color = GureumTheme.colors.gray400
+            color = GureumTheme.colors.gray400,
         )
         Spacer(Modifier.height(24.dp))
         OnboardingThemeCard(
             isDarkTheme = true,
             selected = selectedTheme == GureumThemeType.DARK,
-            onSelected = { viewModel.selectTheme(GureumThemeType.DARK) }
+            onSelected = { onSelectTheme(GureumThemeType.DARK) },
         )
         Spacer(Modifier.height(24.dp))
         OnboardingThemeCard(
             isDarkTheme = false,
             selected = selectedTheme == GureumThemeType.LIGHT,
-            onSelected = { viewModel.selectTheme(GureumThemeType.LIGHT) }
+            onSelected = { onSelectTheme(GureumThemeType.LIGHT) },
         )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -20,23 +19,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.hihihihi.domain.model.Quote
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.presentation.designsystem.components.Medi16Text
 import com.hihihihi.presentation.designsystem.components.Semi18Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.home.components.ErrorView
+import com.hihihihi.presentation.ui.model.QuoteUiModel
 import com.hihihihi.presentation.ui.quotes.component.QuoteContent
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QuotesScreen(
-    viewModel: QuotesViewModel = hiltViewModel()
+    viewModel: QuotesViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     //모달 관련
     var sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
-    var selectedQuote by remember { mutableStateOf<Quote?>(null) }
+    var selectedQuote by remember { mutableStateOf<QuoteUiModel?>(null) }
 
     when {
         uiState.isLoading -> {
@@ -53,16 +53,16 @@ fun QuotesScreen(
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
+                verticalArrangement = Arrangement.Center,
             ) {
                 Semi18Text(
                     "아직 필사가 없어요",
-                    color = GureumTheme.colors.gray500
+                    color = GureumTheme.colors.gray500,
                 )
                 Spacer(Modifier.height(16.dp))
                 Medi16Text(
                     "책에서 인상 깊은 한 줄을 남겨 보세요.",
-                    color = GureumTheme.colors.gray400
+                    color = GureumTheme.colors.gray400,
                 )
             }
         }
@@ -78,7 +78,7 @@ fun QuotesScreen(
                 },
                 onDismiss = {
                     selectedQuote = null
-                }
+                },
             )
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,7 +32,7 @@ import com.hihihihi.presentation.ui.quotes.component.QuoteContent
 fun QuotesScreen(
     viewModel: QuotesViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     //모달 관련
     var sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesScreen.kt
@@ -11,10 +11,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -24,7 +21,6 @@ import com.hihihihi.presentation.designsystem.components.Medi16Text
 import com.hihihihi.presentation.designsystem.components.Semi18Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.home.components.ErrorView
-import com.hihihihi.presentation.ui.model.QuoteUiModel
 import com.hihihihi.presentation.ui.quotes.component.QuoteContent
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -36,7 +32,6 @@ fun QuotesScreen(
     //모달 관련
     var sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
-    var selectedQuote by remember { mutableStateOf<QuoteUiModel?>(null) }
 
     when {
         uiState.isLoading -> {
@@ -70,15 +65,11 @@ fun QuotesScreen(
         else -> {
             QuoteContent(
                 quotes = uiState.quotes,
-                selectedQuote = selectedQuote,
+                selectedQuote = uiState.selectedQuote,
                 sheetState = sheetState,
                 scope = scope,
-                onQuoteSelected = { quote ->
-                    selectedQuote = quote
-                },
-                onDismiss = {
-                    selectedQuote = null
-                },
+                onQuoteSelected = { quote -> viewModel.selectQuote(quote) },
+                onDismiss = { viewModel.selectQuote(null) },
             )
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesUiState.kt
@@ -6,4 +6,5 @@ data class QuotesUiState(
     val isLoading: Boolean = false,
     val quotes: List<QuoteUiModel> = emptyList(),
     val errorMessage: String? = null,
+    val selectedQuote: QuoteUiModel? = null,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesUiState.kt
@@ -1,10 +1,9 @@
 package com.hihihihi.presentation.ui.quotes
 
-import com.hihihihi.domain.model.Quote
+import com.hihihihi.presentation.ui.model.QuoteUiModel
 
-// 홈 화면의 UI 상태를 나타내는 데이터 클래스
 data class QuotesUiState(
-    val isLoading: Boolean = false, // 데이터 로딩 중인지 여부
-    val quotes: List<Quote> = emptyList(), // 사용자 필사 목록
-    val errorMessage: String? = null, // 에러 메세지 (null이면 에러 없음)
+    val isLoading: Boolean = false,
+    val quotes: List<QuoteUiModel> = emptyList(),
+    val errorMessage: String? = null,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesViewModel.kt
@@ -4,11 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hihihihi.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.hihihihi.domain.usecase.quote.GetQuoteUseCase
+import com.hihihihi.presentation.ui.model.QuoteUiModel
 import com.hihihihi.presentation.ui.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -27,16 +29,19 @@ class QuotesViewModel @Inject constructor(
         currentUid?.let { getQuotes(it) }
     }
 
+    fun selectQuote(quote: QuoteUiModel?) {
+        _uiState.update { it.copy(selectedQuote = quote) }
+    }
+
     fun getQuotes(userId: String) {
         viewModelScope.launch {
             try {
-                _uiState.value = QuotesUiState(isLoading = true)
+                _uiState.update { it.copy(isLoading = true) }
                 getQuoteUseCase(userId).collect { quotes ->
-                    _uiState.value = QuotesUiState(quotes = quotes.map { it.toUiModel() }, isLoading = false)
+                    _uiState.update { it.copy(quotes = quotes.map { quote -> quote.toUiModel() }, isLoading = false) }
                 }
             } catch (e: Exception) {
-                _uiState.value =
-                    QuotesUiState(errorMessage = e.message ?: "알 수 없는 오류 발생", isLoading = false)
+                _uiState.update { it.copy(errorMessage = e.message ?: "알 수 없는 오류 발생", isLoading = false) }
             }
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/QuotesViewModel.kt
@@ -2,9 +2,9 @@ package com.hihihihi.presentation.ui.quotes
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.hihihihi.domain.usecase.quote.GetQuoteUseCase
+import com.hihihihi.presentation.ui.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,11 +15,8 @@ import javax.inject.Inject
 @HiltViewModel
 class QuotesViewModel @Inject constructor(
     private val getQuoteUseCase: GetQuoteUseCase,
-    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
 ) : ViewModel() {
-    private val _quotes = MutableStateFlow<List<Quote>>(emptyList())
-    val quotes: StateFlow<List<Quote>> = _quotes.asStateFlow()
-
     private val _uiState = MutableStateFlow(QuotesUiState(isLoading = true))
     val uiState: StateFlow<QuotesUiState> = _uiState.asStateFlow()
 
@@ -35,7 +32,7 @@ class QuotesViewModel @Inject constructor(
             try {
                 _uiState.value = QuotesUiState(isLoading = true)
                 getQuoteUseCase(userId).collect { quotes ->
-                    _uiState.value = QuotesUiState(quotes = quotes, isLoading = false)
+                    _uiState.value = QuotesUiState(quotes = quotes.map { it.toUiModel() }, isLoading = false)
                 }
             } catch (e: Exception) {
                 _uiState.value =

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/component/DetailBottomSheet.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/component/DetailBottomSheet.kt
@@ -20,20 +20,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.presentation.designsystem.components.BodySubText
 import com.hihihihi.presentation.designsystem.components.BookCoverImage
 import com.hihihihi.presentation.designsystem.components.Medi16Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
+import com.hihihihi.presentation.ui.model.QuoteUiModel
 import com.hihihihi.presentation.utils.formatDateToSimpleString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DetailBottomSheet(
-    quote: Quote,
+    quote: QuoteUiModel,
     sheetState: SheetState,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
     ModalBottomSheet(
         onDismissRequest = { onDismiss() },
@@ -44,7 +44,7 @@ fun DetailBottomSheet(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Top
+                verticalAlignment = Alignment.Top,
             ) {
                 // 책 표지
                 BookCoverImage(
@@ -57,7 +57,7 @@ fun DetailBottomSheet(
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.Top
+                        verticalAlignment = Alignment.Top,
                     ) {
                         Column {
                             // 책 제목
@@ -65,7 +65,7 @@ fun DetailBottomSheet(
                                 text = quote.title,
                                 maxLines = 1,
                                 style = GureumTypography.bodyLarge,
-                                overflow = TextOverflow.Ellipsis
+                                overflow = TextOverflow.Ellipsis,
                             )
                             Row {
                                 // 날짜
@@ -91,12 +91,12 @@ fun DetailBottomSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(16.dp))
-                    .background(GureumTheme.colors.bookBackground)
+                    .background(GureumTheme.colors.bookBackground),
             ) {
                 Medi16Text(
                     text = quote.content,
                     color = GureumTheme.colors.gray800,
-                    modifier = Modifier.padding(16.dp)
+                    modifier = Modifier.padding(16.dp),
                 )
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/component/QuoteContent.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/component/QuoteContent.kt
@@ -15,47 +15,44 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
+import com.hihihihi.presentation.ui.model.QuoteUiModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QuoteContent(
-    quotes: List<Quote>,
-    selectedQuote: Quote?,
+    quotes: List<QuoteUiModel>,
+    selectedQuote: QuoteUiModel?,
     scope: CoroutineScope,
-    onQuoteSelected: (Quote) -> Unit,
+    onQuoteSelected: (QuoteUiModel) -> Unit,
     onDismiss: () -> Unit,
-    sheetState: SheetState
+    sheetState: SheetState,
 ) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(GureumTheme.colors.background)
+                .background(GureumTheme.colors.background),
         ) {
             LazyColumn(
                 modifier = Modifier.padding(horizontal = 16.dp),
                 contentPadding = PaddingValues(top = 16.dp, bottom = 32.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 items(quotes) { item ->
                     QuoteItem(
                         item = item,
                         onItemClick = {
                             onQuoteSelected(item)
-                            scope.launch {
-                                sheetState.show()
-                            }
-                        }
+                            scope.launch { sheetState.show() }
+                        },
                     )
                 }
             }
         }
 
-        //모달 시트
         if (selectedQuote != null) {
             DetailBottomSheet(
                 quote = selectedQuote,
@@ -65,8 +62,8 @@ fun QuoteContent(
                         sheetState.hide()
                         onDismiss()
                     }
-                }
+                },
             )
         }
     }
-} 
+}

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/component/QuoteItem.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/quotes/component/QuoteItem.kt
@@ -15,21 +15,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.hihihihi.domain.model.Quote
 import com.hihihihi.presentation.designsystem.components.BookCoverImage
 import com.hihihihi.presentation.designsystem.components.GureumCard
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
+import com.hihihihi.presentation.ui.model.QuoteUiModel
 import com.hihihihi.presentation.utils.formatDateToSimpleString
 
 @Composable
-fun QuoteItem(item: Quote, onItemClick: (Quote) -> Unit) {
+fun QuoteItem(item: QuoteUiModel, onItemClick: (QuoteUiModel) -> Unit) {
     GureumCard(
         corner = 16.dp,
-        onClick = { onItemClick(item) }
+        onClick = { onItemClick(item) },
     ) {
         Row(modifier = Modifier.padding(16.dp)) {
-            //책 이미지
             BookCoverImage(
                 modifier = Modifier
                     .size(width = 60.dp, height = 80.dp)
@@ -39,33 +38,30 @@ fun QuoteItem(item: Quote, onItemClick: (Quote) -> Unit) {
             Spacer(modifier = Modifier.width(12.dp))
             Column(
                 modifier = Modifier.weight(1f),
-                horizontalAlignment = Alignment.Start
+                horizontalAlignment = Alignment.Start,
             ) {
-                //책 제목
                 Text(
                     text = item.title,
                     style = GureumTypography.bodyLarge,
                     color = GureumTheme.colors.gray600,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
-                //날짜
                 Text(
                     text = formatDateToSimpleString(item.createdAt),
                     style = GureumTypography.bodyMedium,
                     color = GureumTheme.colors.gray300,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                //작성한 필사
                 Text(
                     text = item.content,
                     style = GureumTypography.bodyMedium,
                     color = GureumTheme.colors.gray800,
                     maxLines = 4,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,7 +53,7 @@ fun SearchScreen(
     navController: NavController,
     viewModel: SearchViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     //검색어 입력을 위한 상태
     var searchQuery by remember { mutableStateOf("") }
     val focusRequester = remember { FocusRequester() }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,7 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.domain.model.SearchBook
 import com.hihihihi.presentation.designsystem.components.GureumCard
 import com.hihihihi.presentation.designsystem.components.Medi14Text
@@ -50,7 +49,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreen(
-    navController: NavController,
+    onNavigateBack: () -> Unit,
     viewModel: SearchViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -169,7 +168,7 @@ fun SearchScreen(
         SearchTopAppBar(
             query = searchQuery,
             onQueryChange = { searchQuery = it },
-            onBackClick = { navController.popBackStack() },
+            onBackClick = { onNavigateBack() },
             onCloseClick = {
                 searchQuery = ""
                 hasSearched = false

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.hihihihi.domain.model.SearchBook
 import com.hihihihi.presentation.designsystem.components.GureumCard
 import com.hihihihi.presentation.designsystem.components.Medi14Text
 import com.hihihihi.presentation.designsystem.components.Medi16Text
@@ -50,26 +49,22 @@ import kotlinx.coroutines.launch
 @Composable
 fun SearchScreen(
     onNavigateBack: () -> Unit,
-    viewModel: SearchViewModel = hiltViewModel()
+    viewModel: SearchViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    //검색어 입력을 위한 상태
+    //검색어 입력을 위한 상태 (텍스트 필드 중간값 - 검색 실행 전까지 local 유지)
     var searchQuery by remember { mutableStateOf("") }
     val focusRequester = remember { FocusRequester() }
     //포커스와 키보드 제어
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
-    //검색이 한번이라도 실행되었는지 여부
-    var hasSearched by remember { mutableStateOf(false) }
-    //검색 결과 상태
-    var bookToAdd by remember { mutableStateOf<SearchBook?>(null) }
 
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
     //모달시트 상태관리
     val sheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = true
+        skipPartiallyExpanded = true,
     )
 
     LaunchedEffect(uiState.addBookMessage) {
@@ -83,10 +78,7 @@ fun SearchScreen(
 
     LaunchedEffect(uiState.isAddBookSuccess) {
         if (uiState.isAddBookSuccess && !uiState.isAddingBook) {
-            scope.launch {
-                sheetState.hide()
-                bookToAdd = null
-            }
+            scope.launch { sheetState.hide() }
         }
     }
 
@@ -163,7 +155,7 @@ fun SearchScreen(
             .fillMaxWidth()
             .statusBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Top
+        verticalArrangement = Arrangement.Top,
     ) {
         SearchTopAppBar(
             query = searchQuery,
@@ -171,7 +163,6 @@ fun SearchScreen(
             onBackClick = { onNavigateBack() },
             onCloseClick = {
                 searchQuery = ""
-                hasSearched = false
                 focusManager.clearFocus()
                 keyboardController?.hide()
             },
@@ -184,30 +175,29 @@ fun SearchScreen(
                 endToastShown = false
                 //검색 로직
                 viewModel.search(currentQuery)
-                hasSearched = true
-            }
+            },
         )
         //검색이 되지 않았을 경우 보여주는 안내 문구
         when {
-            !hasSearched -> {
+            !uiState.hasSearched -> {
                 Spacer(Modifier.height(74.dp))
                 Medi16Text(
                     text = "책 제목, 작가, 출판사 등\n무엇으로든 검색해 보세요",
                     color = GureumTheme.colors.gray400,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
                 )
             }
 
             uiState.isSearching -> {
                 Spacer(Modifier.height(74.dp))
                 CircularProgressIndicator(
-                    color = GureumTheme.colors.primary
+                    color = GureumTheme.colors.primary,
                 )
                 Spacer(Modifier.height(32.dp))
                 Medi16Text(
                     text = "검색 중입니다...",
                     color = GureumTheme.colors.gray400,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
                 )
             }
 
@@ -216,25 +206,25 @@ fun SearchScreen(
                 Medi16Text(
                     text = "검색 결과가 없습니다.",
                     color = GureumTheme.colors.gray400,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
                 )
             }
 
             else -> {
                 LazyColumn(
                     modifier = Modifier.fillMaxWidth(),
-                    state = listState
+                    state = listState,
                 ) {
                     itemsIndexed(
                         items = uiState.searchResults,
-                        key = { index, item -> "${item.isbn}-$index" }
+                        key = { index, item -> "${item.isbn}-$index" },
                     ) { _, item ->
                         SearchItem(
                             result = item,
                             onItemClick = { selectedBook ->
-                                bookToAdd = selectedBook
+                                viewModel.selectBook(selectedBook)
                                 scope.launch { sheetState.show() }
-                            }
+                            },
                         )
                     }
 
@@ -246,14 +236,14 @@ fun SearchScreen(
                                         .fillMaxWidth()
                                         .height(80.dp),
                                     horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.Center
+                                    verticalArrangement = Arrangement.Center,
                                 ) {
                                     CircularProgressIndicator(color = GureumTheme.colors.primary)
                                     Spacer(modifier = Modifier.height(8.dp))
                                     Medi14Text(
                                         text = "더 많은 결과를 불러오는 중...",
                                         color = GureumTheme.colors.gray400,
-                                        textAlign = TextAlign.Center
+                                        textAlign = TextAlign.Center,
                                     )
                                 }
                             } else {
@@ -271,17 +261,17 @@ fun SearchScreen(
                             ) {
                                 Column(
                                     modifier = Modifier.padding(16.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally
+                                    horizontalAlignment = Alignment.CenterHorizontally,
                                 ) {
                                     Semi14Text(
                                         text = "총 ${uiState.searchResults.size}개의 검색 결과",
-                                        color = GureumTheme.colors.gray500
+                                        color = GureumTheme.colors.gray500,
                                     )
                                     Spacer(modifier = Modifier.height(4.dp))
                                     Medi14Text(
                                         text = "더 정확한 검색을 위해 구체적인 키워드를 사용해보세요",
                                         color = GureumTheme.colors.gray400,
-                                        textAlign = TextAlign.Center
+                                        textAlign = TextAlign.Center,
                                     )
                                 }
                             }
@@ -292,16 +282,16 @@ fun SearchScreen(
                 }
             }
         }
-        //bookToAdd의 상태에 따라 모달시트를 보여주거나 숨김
-        if (bookToAdd != null) {
+        //selectedBook의 상태에 따라 모달시트를 보여주거나 숨김
+        if (uiState.selectedBook != null) {
             AddBookBottomSheet(
-                book = bookToAdd!!,
+                book = uiState.selectedBook!!,
                 sheetState = sheetState,
                 isLoading = uiState.isAddingBook,
                 onDismiss = {
                     scope.launch {
                         sheetState.hide()
-                        bookToAdd = null
+                        viewModel.selectBook(null)
                     }
                 },
                 onConfirm = { book ->
@@ -312,13 +302,13 @@ fun SearchScreen(
                             book.endDate,
                             book.currentPage,
                             book.totalPage,
-                            book.status
+                            book.status,
                         )
                     }
                 },
                 onGetBookPageCount = { isbn, onResult ->
                     viewModel.getBookPageCount(isbn, onResult)
-                }
+                },
             )
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hihihihi.domain.model.SearchBook
 import com.hihihihi.presentation.designsystem.components.GureumCard
 import com.hihihihi.presentation.designsystem.components.Medi14Text
 import com.hihihihi.presentation.designsystem.components.Medi16Text
@@ -43,6 +44,7 @@ import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.search.component.AddBookBottomSheet
 import com.hihihihi.presentation.ui.search.component.SearchItem
 import com.hihihihi.presentation.ui.search.component.SearchTopAppBar
+import com.hihihihi.presentation.ui.search.model.Book
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -52,20 +54,7 @@ fun SearchScreen(
     viewModel: SearchViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    //검색어 입력을 위한 상태 (텍스트 필드 중간값 - 검색 실행 전까지 local 유지)
-    var searchQuery by remember { mutableStateOf("") }
-    val focusRequester = remember { FocusRequester() }
-    //포커스와 키보드 제어
-    val focusManager = LocalFocusManager.current
-    val keyboardController = LocalSoftwareKeyboardController.current
-
-    val scope = rememberCoroutineScope()
     val context = LocalContext.current
-
-    //모달시트 상태관리
-    val sheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = true,
-    )
 
     LaunchedEffect(uiState.addBookMessage) {
         uiState.addBookMessage?.let { message ->
@@ -76,79 +65,89 @@ fun SearchScreen(
         }
     }
 
-    LaunchedEffect(uiState.isAddBookSuccess) {
-        if (uiState.isAddBookSuccess && !uiState.isAddingBook) {
-            scope.launch { sheetState.hide() }
-        }
-    }
+    SearchContent(
+        hasSearched = uiState.hasSearched,
+        isSearching = uiState.isSearching,
+        searchResults = uiState.searchResults,
+        isLoadingMore = uiState.isLoadingMore,
+        hasMore = uiState.hasMore,
+        selectedBook = uiState.selectedBook,
+        isAddingBook = uiState.isAddingBook,
+        isAddBookSuccess = uiState.isAddBookSuccess,
+        onSearch = viewModel::search,
+        onBack = onNavigateBack,
+        onSelectBook = viewModel::selectBook,
+        onDismissSheet = { viewModel.selectBook(null) },
+        onConfirmAdd = { book: Book ->
+            viewModel.addUserBook(book.searchBook, book.startDate, book.endDate, book.currentPage, book.totalPage, book.status)
+        },
+        onGetBookPageCount = viewModel::getBookPageCount,
+        onLoadMore = viewModel::loadMore,
+    )
+}
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SearchContent(
+    hasSearched: Boolean,
+    isSearching: Boolean,
+    searchResults: List<SearchBook>,
+    isLoadingMore: Boolean,
+    hasMore: Boolean,
+    selectedBook: SearchBook?,
+    isAddingBook: Boolean,
+    isAddBookSuccess: Boolean,
+    onSearch: (String) -> Unit,
+    onBack: () -> Unit,
+    onSelectBook: (SearchBook?) -> Unit,
+    onDismissSheet: () -> Unit,
+    onConfirmAdd: (Book) -> Unit,
+    onGetBookPageCount: (String, (Int?) -> Unit) -> Unit,
+    onLoadMore: () -> Unit,
+) {
+    var searchQuery by remember { mutableStateOf("") }
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val listState = rememberLazyListState()
     var endToastShown by remember { mutableStateOf(false) }
-    LaunchedEffect(uiState.query) {
-        endToastShown = false
-    }
 
-    LaunchedEffect(uiState.hasMore, uiState.searchResults.size) {
-        if (!uiState.hasMore &&
-            uiState.searchResults.isNotEmpty() &&
-            !endToastShown &&
-            !uiState.isLoadingMore
-        ) {
-
-            Toast.makeText(context, "모든 검색 결과를 불러왔습니다.", Toast.LENGTH_SHORT).show()
-            endToastShown = true
-        }
-    }
-
-    //화면 진입 시 검색 자동 포커스
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
     }
 
-    val listState = rememberLazyListState()
+    LaunchedEffect(isAddBookSuccess) {
+        if (isAddBookSuccess && !isAddingBook) {
+            scope.launch { sheetState.hide() }
+        }
+    }
 
-    LaunchedEffect(listState) {
-        snapshotFlow {
-            listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
-        }.collect { lastVisibleIndex ->
-            // 여기서는 스크롤 위치만 감지하고, 실제 로딩 조건은 별도로 체크
-            if (lastVisibleIndex != null) {
-                val currentState = viewModel.uiState.value // viewModel에서 직접 가져오기
-                val totalItems = currentState.searchResults.size
+    LaunchedEffect(searchResults.size) {
+        endToastShown = false
+    }
 
-                if (totalItems > 0) {
-                    val reachedBottom = lastVisibleIndex >= totalItems - 2
-
-                    if (reachedBottom && currentState.hasMore && !currentState.isLoadingMore) {
-                        viewModel.loadMore()
-                    }
-                }
-            }
+    LaunchedEffect(hasMore, searchResults.size) {
+        if (!hasMore && searchResults.isNotEmpty() && !endToastShown && !isLoadingMore) {
+            Toast.makeText(context, "모든 검색 결과를 불러왔습니다.", Toast.LENGTH_SHORT).show()
+            endToastShown = true
         }
     }
 
     LaunchedEffect(listState) {
         snapshotFlow {
             val layoutInfo = listState.layoutInfo
-            val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index
-            val totalItems = layoutInfo.totalItemsCount
-
-            lastVisibleIndex != null && lastVisibleIndex >= totalItems - 3
+            val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index
+            val total = layoutInfo.totalItemsCount
+            lastVisible != null && lastVisible >= total - 3
         }.collect { shouldLoadMore ->
-            if (shouldLoadMore) {
-                val currentState = viewModel.uiState.value
-
-                val canLoad = currentState.hasMore &&
-                        !currentState.isLoadingMore &&
-                        !currentState.isSearching &&
-                        currentState.searchResults.isNotEmpty()
-
-                if (canLoad) {
-                    viewModel.loadMore()
-                }
+            if (shouldLoadMore && hasMore && !isLoadingMore && !isSearching && searchResults.isNotEmpty()) {
+                onLoadMore()
             }
         }
     }
-
 
     Column(
         modifier = Modifier
@@ -160,7 +159,7 @@ fun SearchScreen(
         SearchTopAppBar(
             query = searchQuery,
             onQueryChange = { searchQuery = it },
-            onBackClick = { onNavigateBack() },
+            onBackClick = onBack,
             onCloseClick = {
                 searchQuery = ""
                 focusManager.clearFocus()
@@ -168,18 +167,15 @@ fun SearchScreen(
             },
             focusRequester = focusRequester,
             onSearch = { currentQuery ->
-                //검색 버튼이 눌렸을 때
-                //키보드 내리고 포커스 해제
                 keyboardController?.hide()
                 focusManager.clearFocus()
                 endToastShown = false
-                //검색 로직
-                viewModel.search(currentQuery)
+                onSearch(currentQuery)
             },
         )
-        //검색이 되지 않았을 경우 보여주는 안내 문구
+
         when {
-            !uiState.hasSearched -> {
+            !hasSearched -> {
                 Spacer(Modifier.height(74.dp))
                 Medi16Text(
                     text = "책 제목, 작가, 출판사 등\n무엇으로든 검색해 보세요",
@@ -188,140 +184,102 @@ fun SearchScreen(
                 )
             }
 
-            uiState.isSearching -> {
+            isSearching -> {
                 Spacer(Modifier.height(74.dp))
-                CircularProgressIndicator(
-                    color = GureumTheme.colors.primary,
-                )
+                CircularProgressIndicator(color = GureumTheme.colors.primary)
                 Spacer(Modifier.height(32.dp))
-                Medi16Text(
-                    text = "검색 중입니다...",
-                    color = GureumTheme.colors.gray400,
-                    textAlign = TextAlign.Center,
-                )
+                Medi16Text(text = "검색 중입니다...", color = GureumTheme.colors.gray400, textAlign = TextAlign.Center)
             }
 
-            uiState.searchResults.isEmpty() -> {
+            searchResults.isEmpty() -> {
                 Spacer(Modifier.height(74.dp))
-                Medi16Text(
-                    text = "검색 결과가 없습니다.",
-                    color = GureumTheme.colors.gray400,
-                    textAlign = TextAlign.Center,
-                )
+                Medi16Text(text = "검색 결과가 없습니다.", color = GureumTheme.colors.gray400, textAlign = TextAlign.Center)
             }
 
             else -> {
-                LazyColumn(
-                    modifier = Modifier.fillMaxWidth(),
-                    state = listState,
-                ) {
+                LazyColumn(modifier = Modifier.fillMaxWidth(), state = listState) {
                     itemsIndexed(
-                        items = uiState.searchResults,
+                        items = searchResults,
                         key = { index, item -> "${item.isbn}-$index" },
                     ) { _, item ->
                         SearchItem(
                             result = item,
-                            onItemClick = { selectedBook ->
-                                viewModel.selectBook(selectedBook)
+                            onItemClick = { book ->
+                                onSelectBook(book)
                                 scope.launch { sheetState.show() }
                             },
                         )
                     }
 
-                    if (uiState.isLoadingMore) {
+                    if (isLoadingMore) {
                         item(key = "footer") {
-                            if (uiState.isLoadingMore) {
-                                Column(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(80.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.Center,
-                                ) {
-                                    CircularProgressIndicator(color = GureumTheme.colors.primary)
-                                    Spacer(modifier = Modifier.height(8.dp))
-                                    Medi14Text(
-                                        text = "더 많은 결과를 불러오는 중...",
-                                        color = GureumTheme.colors.gray400,
-                                        textAlign = TextAlign.Center,
-                                    )
-                                }
-                            } else {
-                                Spacer(Modifier.height(8.dp))
+                            Column(
+                                modifier = Modifier.fillMaxWidth().height(80.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.Center,
+                            ) {
+                                CircularProgressIndicator(color = GureumTheme.colors.primary)
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Medi14Text(text = "더 많은 결과를 불러오는 중...", color = GureumTheme.colors.gray400, textAlign = TextAlign.Center)
                             }
                         }
                     }
 
-                    if (!uiState.hasMore && uiState.searchResults.isNotEmpty() && !uiState.isLoadingMore) {
+                    if (!hasMore && searchResults.isNotEmpty() && !isLoadingMore) {
                         item(key = "end_notice") {
-                            GureumCard(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(16.dp),
-                            ) {
-                                Column(
-                                    modifier = Modifier.padding(16.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                ) {
-                                    Semi14Text(
-                                        text = "총 ${uiState.searchResults.size}개의 검색 결과",
-                                        color = GureumTheme.colors.gray500,
-                                    )
+                            GureumCard(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                                Column(modifier = Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+                                    Semi14Text(text = "총 ${searchResults.size}개의 검색 결과", color = GureumTheme.colors.gray500)
                                     Spacer(modifier = Modifier.height(4.dp))
-                                    Medi14Text(
-                                        text = "더 정확한 검색을 위해 구체적인 키워드를 사용해보세요",
-                                        color = GureumTheme.colors.gray400,
-                                        textAlign = TextAlign.Center,
-                                    )
+                                    Medi14Text(text = "더 정확한 검색을 위해 구체적인 키워드를 사용해보세요", color = GureumTheme.colors.gray400, textAlign = TextAlign.Center)
                                 }
                             }
-
                             Spacer(Modifier.height(50.dp))
                         }
                     }
                 }
             }
         }
-        //selectedBook의 상태에 따라 모달시트를 보여주거나 숨김
-        if (uiState.selectedBook != null) {
+
+        if (selectedBook != null) {
             AddBookBottomSheet(
-                book = uiState.selectedBook!!,
+                book = selectedBook,
                 sheetState = sheetState,
-                isLoading = uiState.isAddingBook,
+                isLoading = isAddingBook,
                 onDismiss = {
                     scope.launch {
                         sheetState.hide()
-                        viewModel.selectBook(null)
+                        onDismissSheet()
                     }
                 },
-                onConfirm = { book ->
-                    scope.launch {
-                        viewModel.addUserBook(
-                            book.searchBook,
-                            book.startDate,
-                            book.endDate,
-                            book.currentPage,
-                            book.totalPage,
-                            book.status,
-                        )
-                    }
-                },
-                onGetBookPageCount = { isbn, onResult ->
-                    viewModel.getBookPageCount(isbn, onResult)
-                },
+                onConfirm = { book -> onConfirmAdd(book) },
+                onGetBookPageCount = onGetBookPageCount,
             )
         }
     }
 }
 
-
 @Preview(name = "DarkMode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(name = "LightMode", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
-private fun SearchPreView() {
+private fun SearchPreview() {
     GureumPageTheme {
-//        SearchScreen(
-//            navController = rememberNavController(),
-//        )
+        SearchContent(
+            hasSearched = false,
+            isSearching = false,
+            searchResults = emptyList(),
+            isLoadingMore = false,
+            hasMore = false,
+            selectedBook = null,
+            isAddingBook = false,
+            isAddBookSuccess = false,
+            onSearch = {},
+            onBack = {},
+            onSelectBook = {},
+            onDismissSheet = {},
+            onConfirmAdd = {},
+            onGetBookPageCount = { _, _ -> },
+            onLoadMore = {},
+        )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchUiState.kt
@@ -14,5 +14,7 @@ data class SearchUiState(
     val hasMore: Boolean = true,
     val isAddingBook: Boolean = false,
     val addBookMessage: String? = null,
-    val isAddBookSuccess: Boolean = false
+    val isAddBookSuccess: Boolean = false,
+    val hasSearched: Boolean = false,
+    val selectedBook: SearchBook? = null,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchViewModel.kt
@@ -75,29 +75,36 @@ class SearchViewModel @Inject constructor(
         if (state.isLoadingMore || state.isPaging || !state.hasMore) return
 
         viewModelScope.launch {
+            // 요청 시점의 쿼리를 캡처해 유효성 검증에 사용
+            val requestQuery = state.query
+            val snapshotPage = state.page
+            val snapshotResults = state.searchResults
             _uiState.update { it.copy(isLoadingMore = true) }
 
             try {
-                val nextPage = state.page + 1
+                val nextPage = snapshotPage + 1
                 val newResults =
-                    searchBooksUseCase(state.query, page = nextPage, pageSize = PAGE_SIZE).getOrThrow()
+                    searchBooksUseCase(requestQuery, page = nextPage, pageSize = PAGE_SIZE).getOrThrow()
 
-                val before = state.searchResults
-                val merged = (before + newResults).distinctBy { it.isbn }
+                val merged = (snapshotResults + newResults).distinctBy { it.isbn }
+                val actuallyGrew = merged.size > snapshotResults.size
 
-                val actuallyGrew = merged.size > before.size
-
-                _uiState.value = state.copy(
-                    searchResults = merged,
-                    page = nextPage,
-                    isLoadingMore = false,
-                    hasMore = canLoadMore(merged.size, nextPage) && actuallyGrew && newResults.isNotEmpty(),
-                )
-            } catch (e: Exception) {
-                _uiState.value = state.copy(
-                    isLoadingMore = false,
-                    hasMore = false,
-                )
+                _uiState.update { current ->
+                    // 응답을 기다리는 동안 새 검색이 시작됐으면 결과를 버리고 로딩 플래그만 해제
+                    if (current.query != requestQuery) {
+                        current.copy(isLoadingMore = false)
+                    } else {
+                        current.copy(
+                            searchResults = merged,
+                            page = nextPage,
+                            isLoadingMore = false,
+                            hasMore = canLoadMore(merged.size, nextPage) && actuallyGrew && newResults.isNotEmpty(),
+                        )
+                    }
+                }
+            } catch (_: Exception) {
+                // 일시적 오류(타임아웃 등)에서는 hasMore를 변경하지 않아 사용자가 재시도 가능하게 유지
+                _uiState.update { current -> current.copy(isLoadingMore = false) }
             }
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/search/SearchViewModel.kt
@@ -36,13 +36,18 @@ class SearchViewModel @Inject constructor(
     private val currentUid: String?
         get() = getCurrentUserIdUseCase()
 
+    fun selectBook(book: SearchBook?) {
+        _uiState.update { it.copy(selectedBook = book) }
+    }
+
     fun search(query: String) {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(
                 query = query,
                 isSearching = true,
                 searchResults = emptyList(),
-                page = 1
+                page = 1,
+                hasSearched = true,
             )
             try {
                 val results = searchBooksUseCase(query, page = 1, pageSize = PAGE_SIZE).getOrThrow()
@@ -52,14 +57,14 @@ class SearchViewModel @Inject constructor(
                     searchResults = dedup,
                     isSearching = false,
                     hasMore = canLoadMore(dedup.size, 1),
-                    page = 1
+                    page = 1,
                 )
             } catch (_: Exception) {
                 _uiState.value = _uiState.value.copy(
                     searchResults = emptyList(),
                     isSearching = false,
                     hasMore = false,
-                    page = 0
+                    page = 0,
                 )
             }
         }
@@ -86,12 +91,12 @@ class SearchViewModel @Inject constructor(
                     searchResults = merged,
                     page = nextPage,
                     isLoadingMore = false,
-                    hasMore = canLoadMore(merged.size, nextPage) && actuallyGrew && newResults.isNotEmpty()
+                    hasMore = canLoadMore(merged.size, nextPage) && actuallyGrew && newResults.isNotEmpty(),
                 )
             } catch (e: Exception) {
                 _uiState.value = state.copy(
                     isLoadingMore = false,
-                    hasMore = false
+                    hasMore = false,
                 )
             }
         }
@@ -167,7 +172,7 @@ class SearchViewModel @Inject constructor(
                     color = null,
                     icon = null,
                     deleted = false,
-                    bookImage = searchBook.coverImageUrl
+                    bookImage = searchBook.coverImageUrl,
                 )
 
                 val result = addUserBookUseCase(uid, userBook, mindmap, rootNode)
@@ -177,7 +182,8 @@ class SearchViewModel @Inject constructor(
                         _uiState.value.copy(
                             isAddingBook = false,
                             addBookMessage = "책이 추가되었습니다",
-                            isAddBookSuccess = true
+                            isAddBookSuccess = true,
+                            selectedBook = null,
                         )
                 } else {
                     val errorMessage = result.exceptionOrNull()?.message ?: "알 수 없는 오류가 발생했습니다."
@@ -185,7 +191,7 @@ class SearchViewModel @Inject constructor(
                         _uiState.value.copy(
                             isAddingBook = false,
                             addBookMessage = errorMessage,
-                            isAddBookSuccess = false
+                            isAddBookSuccess = false,
                         )
                 }
             } catch (e: Exception) {
@@ -193,7 +199,7 @@ class SearchViewModel @Inject constructor(
                     _uiState.value.copy(
                         isAddingBook = false,
                         addBookMessage = e.message ?: "알 수 없는 오류가 발생했습니다.",
-                        isAddBookSuccess = false
+                        isAddBookSuccess = false,
                     )
             }
         }
@@ -202,7 +208,7 @@ class SearchViewModel @Inject constructor(
     fun clearMessage() {
         _uiState.value = _uiState.value.copy(
             addBookMessage = "",
-            isAddBookSuccess = false
+            isAddBookSuccess = false,
         )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,18 +39,20 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.presentation.designsystem.components.GureumLinearProgressBar
 import com.hihihihi.presentation.designsystem.components.Medi12Text
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
-import com.hihihihi.presentation.navigation.NavigationRoute
 import com.hihihihi.presentation.notification.reminder.ReminderScheduler
 import com.hihihihi.presentation.notification.summary.SummaryScheduler
 
 @Composable
 fun SplashView(
-    navController: NavHostController,
+    onNavigateToLogin: () -> Unit,
+    onNavigateToOnBoarding: () -> Unit,
+    onNavigateToHome: () -> Unit,
+    onNavigateToWidget: (String) -> Unit,
     viewModel: SplashViewModel = hiltViewModel(),
     pendingWidgetRoute: String? = null,
 ) {
@@ -139,34 +140,10 @@ fun SplashView(
 
         if (proceed && !uiState.isLoading) {
             when (val target = uiState.navTarget) {
-                SplashViewModel.NavTarget.Login -> {
-                    navController.navigate(NavigationRoute.Login.route) {
-                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
-                        launchSingleTop = true
-                    }
-                }
-
-                SplashViewModel.NavTarget.Onboarding -> {
-                    navController.navigate(NavigationRoute.OnBoarding.route) {
-                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
-                        launchSingleTop = true
-                    }
-                }
-
-                SplashViewModel.NavTarget.Home -> {
-                    navController.navigate(NavigationRoute.Home.route) {
-                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
-                        launchSingleTop = true
-                    }
-                }
-
-                is SplashViewModel.NavTarget.Widget -> {
-                    navController.navigate(target.route) {
-                        popUpTo(NavigationRoute.Splash.route) { inclusive = true }
-                        launchSingleTop = true
-                    }
-                }
-
+                SplashViewModel.NavTarget.Login -> onNavigateToLogin()
+                SplashViewModel.NavTarget.Onboarding -> onNavigateToOnBoarding()
+                SplashViewModel.NavTarget.Home -> onNavigateToHome()
+                is SplashViewModel.NavTarget.Widget -> onNavigateToWidget(target.route)
                 else -> {
                     // Loading, NoNetwork 상태는 별도 UI에서 처리
                 }
@@ -215,7 +192,7 @@ fun SplashView(
                 containerColor = GureumTheme.colors.card,
                 confirmButton = {
                     TextButton(onClick = {
-                        (navController.context as? Activity)?.finish()
+                        (context as? Activity)?.finish()
                     }) { Text("앱 종료") }
                 }
             )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,16 +58,13 @@ fun SplashView(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    var askedOnce by rememberSaveable { mutableStateOf(false) }
-    var proceed by rememberSaveable { mutableStateOf(false) }
-    var kicked by rememberSaveable { mutableStateOf(false) }
     var showProgress by remember { mutableStateOf(false) }
     var startAnimation by remember { mutableStateOf(false) }
 
     val launcher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { isGranted: Boolean ->
-        proceed = true
+        viewModel.onPermissionResult()
         if (isGranted) Toast.makeText(context, "권한이 허용되었습니다.", Toast.LENGTH_SHORT).show()
         else Toast.makeText(context, "권한이 거부되었습니다.", Toast.LENGTH_SHORT).show()
     }
@@ -103,42 +99,36 @@ fun SplashView(
         animationSpec = tween(durationMillis = 300), label = "",
     )
 
-    LaunchedEffect(askedOnce) {
+    LaunchedEffect(uiState.permissionAsked) {
         if (Build.VERSION.SDK_INT >= 33) {
             val granted = ContextCompat.checkSelfPermission(
                 context, Manifest.permission.POST_NOTIFICATIONS,
             ) == PackageManager.PERMISSION_GRANTED
-            if (!granted && !askedOnce) {
-                askedOnce = true
+            if (!granted && !uiState.permissionAsked) {
+                viewModel.markPermissionAsked()
                 launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 return@LaunchedEffect
             }
         }
-        proceed = true
+        viewModel.onPermissionResult()
     }
 
-    // 권한 허용 후 네트워크 상태 확인
-    LaunchedEffect(proceed) {
-        if (proceed && !kicked) {
-            kicked = true
+    // 권한 처리 후 스케줄러 설정
+    LaunchedEffect(uiState.permissionHandled) {
+        if (uiState.permissionHandled && !uiState.schedulersSetUp) {
+            viewModel.markSchedulersSetUp()
             showProgress = true
-        }
 
-        if (proceed) {
             ReminderScheduler.scheduleDaily(context, hour = 22, minute = 0)
-
             SummaryScheduler.scheduleWeekly(context)   // 월 09:00
             SummaryScheduler.scheduleMonthly(context)  // 1일 09:00
             SummaryScheduler.scheduleYearly(context)   // 1월 1일 09:00
-
-            // 주, 월, 년 알림 테스트
-//            SummaryScheduler.scheduleAllIn(context, 5)
         }
     }
 
-    LaunchedEffect(proceed, uiState.isLoading, uiState.navTarget) {
+    LaunchedEffect(uiState.permissionHandled, uiState.isLoading, uiState.navTarget) {
 
-        if (proceed && !uiState.isLoading) {
+        if (uiState.permissionHandled && !uiState.isLoading) {
             when (val target = uiState.navTarget) {
                 SplashViewModel.NavTarget.Login -> onNavigateToLogin()
                 SplashViewModel.NavTarget.Onboarding -> onNavigateToOnBoarding()

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,7 +56,7 @@ fun SplashView(
     pendingWidgetRoute: String? = null,
 ) {
     val context = LocalContext.current
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     var askedOnce by rememberSaveable { mutableStateOf(false) }
     var proceed by rememberSaveable { mutableStateOf(false) }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
@@ -35,12 +35,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.presentation.designsystem.components.GureumLinearProgressBar
 import com.hihihihi.presentation.designsystem.components.Medi12Text
+import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.notification.reminder.ReminderScheduler
@@ -83,7 +86,6 @@ fun SplashView(
         animationSpec = tween(durationMillis = 1200), label = "",
     )
 
-    // 위젯 라우트를 먼저 ViewModel에 설정
     LaunchedEffect(pendingWidgetRoute) {
         if (pendingWidgetRoute != null) {
             viewModel.setPendingWidgetRoute(pendingWidgetRoute)
@@ -113,21 +115,19 @@ fun SplashView(
         viewModel.onPermissionResult()
     }
 
-    // 권한 처리 후 스케줄러 설정
     LaunchedEffect(uiState.permissionHandled) {
         if (uiState.permissionHandled && !uiState.schedulersSetUp) {
             viewModel.markSchedulersSetUp()
             showProgress = true
 
             ReminderScheduler.scheduleDaily(context, hour = 22, minute = 0)
-            SummaryScheduler.scheduleWeekly(context)   // 월 09:00
-            SummaryScheduler.scheduleMonthly(context)  // 1일 09:00
-            SummaryScheduler.scheduleYearly(context)   // 1월 1일 09:00
+            SummaryScheduler.scheduleWeekly(context)
+            SummaryScheduler.scheduleMonthly(context)
+            SummaryScheduler.scheduleYearly(context)
         }
     }
 
     LaunchedEffect(uiState.permissionHandled, uiState.isLoading, uiState.navTarget) {
-
         if (uiState.permissionHandled && !uiState.isLoading) {
             when (val target = uiState.navTarget) {
                 SplashViewModel.NavTarget.Login -> onNavigateToLogin()
@@ -141,6 +141,29 @@ fun SplashView(
         }
     }
 
+    SplashContent(
+        isNoNetwork = uiState.navTarget == SplashViewModel.NavTarget.NoNetwork,
+        isLoading = uiState.isLoading,
+        loadingMessage = uiState.loadingMessage,
+        showProgress = showProgress,
+        alpha = alpha,
+        offsetY = offsetY,
+        animatedProgress = animatedProgress,
+        onExit = { (context as? Activity)?.finish() },
+    )
+}
+
+@Composable
+private fun SplashContent(
+    isNoNetwork: Boolean,
+    isLoading: Boolean,
+    loadingMessage: String,
+    showProgress: Boolean,
+    alpha: Float,
+    offsetY: Dp,
+    animatedProgress: Float,
+    onExit: () -> Unit,
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -174,23 +197,19 @@ fun SplashView(
             )
         }
 
-        if (uiState.navTarget == SplashViewModel.NavTarget.NoNetwork) {
+        if (isNoNetwork) {
             AlertDialog(
                 onDismissRequest = { },
                 title = { Text("네트워크 오류") },
                 text = { Text("인터넷 연결이 필요합니다.\n연결 후 다시 시도해주세요.") },
                 containerColor = GureumTheme.colors.card,
                 confirmButton = {
-                    TextButton(
-                        onClick = {
-                            (context as? Activity)?.finish()
-                        },
-                    ) { Text("앱 종료") }
+                    TextButton(onClick = onExit) { Text("앱 종료") }
                 },
             )
         }
 
-        if (showProgress && uiState.isLoading && uiState.loadingMessage.isNotEmpty()) {
+        if (showProgress && isLoading && loadingMessage.isNotEmpty()) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
@@ -199,7 +218,7 @@ fun SplashView(
                     .padding(16.dp),
             ) {
                 Medi12Text(
-                    uiState.loadingMessage,
+                    loadingMessage,
                     style = GureumTypography.bodyMedium.copy(
                         fontWeight = FontWeight.Bold,
                     ),
@@ -212,5 +231,23 @@ fun SplashView(
                 )
             }
         }
+    }
+}
+
+@Preview(name = "Light", showBackground = true)
+@Preview(name = "Dark")
+@Composable
+private fun SplashPreview() {
+    GureumPageTheme {
+        SplashContent(
+            isNoNetwork = false,
+            isLoading = true,
+            loadingMessage = "데이터를 불러오는 중...",
+            showProgress = true,
+            alpha = 1f,
+            offsetY = 0.dp,
+            animatedProgress = 0.6f,
+            onExit = {},
+        )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashScreen.kt
@@ -52,9 +52,9 @@ fun SplashView(
     onNavigateToLogin: () -> Unit,
     onNavigateToOnBoarding: () -> Unit,
     onNavigateToHome: () -> Unit,
-    onNavigateToWidget: (String) -> Unit,
+    onNavigateToWidget: (Any) -> Unit,
     viewModel: SplashViewModel = hiltViewModel(),
-    pendingWidgetRoute: String? = null,
+    pendingWidgetRoute: Any? = null,
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -66,7 +66,7 @@ fun SplashView(
     var startAnimation by remember { mutableStateOf(false) }
 
     val launcher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
+        ActivityResultContracts.RequestPermission(),
     ) { isGranted: Boolean ->
         proceed = true
         if (isGranted) Toast.makeText(context, "권한이 허용되었습니다.", Toast.LENGTH_SHORT).show()
@@ -79,12 +79,12 @@ fun SplashView(
         finishedListener = {
             showProgress = true
             viewModel.checkNetworkAndProceed()
-        }
+        },
     )
 
     val offsetY by animateDpAsState(
         targetValue = if (startAnimation) 0.dp else 40.dp,
-        animationSpec = tween(durationMillis = 1200), label = ""
+        animationSpec = tween(durationMillis = 1200), label = "",
     )
 
     // 위젯 라우트를 먼저 ViewModel에 설정
@@ -100,13 +100,13 @@ fun SplashView(
 
     val animatedProgress by animateFloatAsState(
         targetValue = uiState.progress,
-        animationSpec = tween(durationMillis = 300), label = ""
+        animationSpec = tween(durationMillis = 300), label = "",
     )
 
     LaunchedEffect(askedOnce) {
         if (Build.VERSION.SDK_INT >= 33) {
             val granted = ContextCompat.checkSelfPermission(
-                context, Manifest.permission.POST_NOTIFICATIONS
+                context, Manifest.permission.POST_NOTIFICATIONS,
             ) == PackageManager.PERMISSION_GRANTED
             if (!granted && !askedOnce) {
                 askedOnce = true
@@ -158,29 +158,29 @@ fun SplashView(
                 brush = Brush.linearGradient(
                     colors = if (GureumTheme.isDarkTheme) listOf(
                         GureumTheme.colors.background,
-                        Color(0xFF00153F)
+                        Color(0xFF00153F),
                     ) else listOf(
                         Color(0xFF51C1F6),
                         Color(0xFFE1F5FE),
-                        Color(0xFFFFFDE7)
-                    )
-                )
-            )
+                        Color(0xFFFFFDE7),
+                    ),
+                ),
+            ),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
-            modifier = Modifier.align(Alignment.Center)
+            modifier = Modifier.align(Alignment.Center),
         ) {
             Text(
                 "구름한장",
                 style = GureumTypography.displayMedium.copy(
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
                 ),
                 color = GureumTheme.colors.gray900,
                 modifier = Modifier
                     .offset(y = offsetY)
-                    .graphicsLayer { this.alpha = alpha }
+                    .graphicsLayer { this.alpha = alpha },
             )
         }
 
@@ -191,10 +191,12 @@ fun SplashView(
                 text = { Text("인터넷 연결이 필요합니다.\n연결 후 다시 시도해주세요.") },
                 containerColor = GureumTheme.colors.card,
                 confirmButton = {
-                    TextButton(onClick = {
-                        (context as? Activity)?.finish()
-                    }) { Text("앱 종료") }
-                }
+                    TextButton(
+                        onClick = {
+                            (context as? Activity)?.finish()
+                        },
+                    ) { Text("앱 종료") }
+                },
             )
         }
 
@@ -204,14 +206,14 @@ fun SplashView(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 100.dp)
-                    .padding(16.dp)
+                    .padding(16.dp),
             ) {
                 Medi12Text(
                     uiState.loadingMessage,
                     style = GureumTypography.bodyMedium.copy(
-                        fontWeight = FontWeight.Bold
+                        fontWeight = FontWeight.Bold,
                     ),
-                    color = GureumTheme.colors.gray900
+                    color = GureumTheme.colors.gray900,
                 )
                 Spacer(Modifier.height(8.dp))
                 GureumLinearProgressBar(

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashUiState.kt
@@ -4,6 +4,9 @@ data class SplashUiState(
     val navTarget: SplashViewModel.NavTarget = SplashViewModel.NavTarget.Loading,
     val loadingMessage: String = "구름이를 깨우는 중...",
     val progress: Float = 0f,
-    val isLoading: Boolean = true
+    val isLoading: Boolean = true,
+    val permissionAsked: Boolean = false,
+    val permissionHandled: Boolean = false,
+    val schedulersSetUp: Boolean = false,
 )
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashViewModel.kt
@@ -54,75 +54,54 @@ class SplashViewModel @Inject constructor(
 
     fun checkNetworkAndProceed() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(
-                loadingMessage = "구름한장을 시작하는 중...",
-                progress = 0.2f,
-            )
+            _uiState.update { it.copy(loadingMessage = "구름한장을 시작하는 중...", progress = 0.2f) }
             delay(400)
 
-            _uiState.value = _uiState.value.copy(
-                loadingMessage = "구름이가 네트워크 연결을 확인하는중...",
-                progress = 0.4f,
-            )
+            _uiState.update { it.copy(loadingMessage = "구름이가 네트워크 연결을 확인하는중...", progress = 0.4f) }
             delay(400)
 
             if (!networkManager.checkCurrentNetwork()) {
-                _uiState.value = _uiState.value.copy(
-                    navTarget = NavTarget.NoNetwork,
-                    isLoading = false,
-                    progress = 1f,
-                )
+                _uiState.update { it.copy(navTarget = NavTarget.NoNetwork, isLoading = false, progress = 1f) }
                 return@launch
             }
 
             val userId = getCurrentUserIdUseCase()
-            _uiState.value = _uiState.value.copy(
-                loadingMessage = "구름이가 사용자 정보를 확인하는중...",
-                progress = 0.7f,
-            )
+            _uiState.update { it.copy(loadingMessage = "구름이가 사용자 정보를 확인하는중...", progress = 0.7f) }
             delay(400)
 
             if (userId == null) {
-                _uiState.value = _uiState.value.copy(
-                    loadingMessage = "로그인이 필요해요",
-                    navTarget = NavTarget.Login,
-                    progress = 0.99f,
-                    isLoading = false,
-                )
+                _uiState.update {
+                    it.copy(
+                        loadingMessage = "로그인이 필요해요",
+                        navTarget = NavTarget.Login,
+                        progress = 0.99f,
+                        isLoading = false,
+                    )
+                }
             } else {
                 val profile = getUserUseCase(userId).getOrNull()
                 val hasNickname = !profile?.nickname.isNullOrBlank()
                 if (hasNickname) setOnboardingCompleteUseCase(userId, true)
 
                 val finalTarget = when {
-                    !hasNickname -> {
-                        NavTarget.Onboarding
-                    }
-
-                    pendingWidgetRoute != null -> {
-                        NavTarget.Widget(pendingWidgetRoute!!)
-                    }
-
-                    else -> {
-                        NavTarget.Home
-                    }
+                    !hasNickname -> NavTarget.Onboarding
+                    pendingWidgetRoute != null -> NavTarget.Widget(pendingWidgetRoute!!)
+                    else -> NavTarget.Home
                 }
 
-                _uiState.value = _uiState.value.copy(
-                    loadingMessage = when (finalTarget) {
-                        is NavTarget.Onboarding -> "처음 오셨네요! 구름한장을 소개해드릴게요"
-                        is NavTarget.Widget -> "위젯에서 요청한 페이지로 이동중..."
-                        else -> "구름이와 홈으로 이동중"
-                    },
-                    progress = 0.99f,
-                )
+                _uiState.update {
+                    it.copy(
+                        loadingMessage = when (finalTarget) {
+                            is NavTarget.Onboarding -> "처음 오셨네요! 구름한장을 소개해드릴게요"
+                            is NavTarget.Widget -> "위젯에서 요청한 페이지로 이동중..."
+                            else -> "구름이와 홈으로 이동중"
+                        },
+                        progress = 0.99f,
+                    )
+                }
                 delay(500)
 
-                _uiState.value = _uiState.value.copy(
-                    progress = 1f,
-                    isLoading = false,
-                    navTarget = finalTarget,
-                )
+                _uiState.update { it.copy(progress = 1f, isLoading = false, navTarget = finalTarget) }
             }
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashViewModel.kt
@@ -18,7 +18,7 @@ class SplashViewModel @Inject constructor(
     private val setOnboardingCompleteUseCase: SetOnboardingCompleteUseCase,
     private val getUserUseCase: GetUserUseCase,
     private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
-    private val networkManager: NetworkMonitor
+    private val networkManager: NetworkMonitor,
 ) : ViewModel() {
 
     sealed interface NavTarget {
@@ -27,16 +27,15 @@ class SplashViewModel @Inject constructor(
         data object Onboarding : NavTarget
         data object Home : NavTarget
         data object NoNetwork : NavTarget
-        data class Widget(val route: String) : NavTarget
+        data class Widget(val route: Any) : NavTarget
     }
 
     private val _uiState = MutableStateFlow(SplashUiState())
     val uiState: StateFlow<SplashUiState> = _uiState
 
-    // 위젯 라우트를 저장할 변수
-    private var pendingWidgetRoute: String? = null
+    private var pendingWidgetRoute: Any? = null
 
-    fun setPendingWidgetRoute(route: String?) {
+    fun setPendingWidgetRoute(route: Any?) {
         pendingWidgetRoute = route
     }
 
@@ -44,13 +43,13 @@ class SplashViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(
                 loadingMessage = "구름한장을 시작하는 중...",
-                progress = 0.2f
+                progress = 0.2f,
             )
             delay(400)
 
             _uiState.value = _uiState.value.copy(
                 loadingMessage = "구름이가 네트워크 연결을 확인하는중...",
-                progress = 0.4f
+                progress = 0.4f,
             )
             delay(400)
 
@@ -58,7 +57,7 @@ class SplashViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(
                     navTarget = NavTarget.NoNetwork,
                     isLoading = false,
-                    progress = 1f
+                    progress = 1f,
                 )
                 return@launch
             }
@@ -66,7 +65,7 @@ class SplashViewModel @Inject constructor(
             val userId = getCurrentUserIdUseCase()
             _uiState.value = _uiState.value.copy(
                 loadingMessage = "구름이가 사용자 정보를 확인하는중...",
-                progress = 0.7f
+                progress = 0.7f,
             )
             delay(400)
 
@@ -75,7 +74,7 @@ class SplashViewModel @Inject constructor(
                     loadingMessage = "로그인이 필요해요",
                     navTarget = NavTarget.Login,
                     progress = 0.99f,
-                    isLoading = false
+                    isLoading = false,
                 )
             } else {
                 val profile = getUserUseCase(userId).getOrNull()
@@ -109,7 +108,7 @@ class SplashViewModel @Inject constructor(
                 _uiState.value = _uiState.value.copy(
                     progress = 1f,
                     isLoading = false,
-                    navTarget = finalTarget
+                    navTarget = finalTarget,
                 )
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/splash/SplashViewModel.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -37,6 +38,18 @@ class SplashViewModel @Inject constructor(
 
     fun setPendingWidgetRoute(route: Any?) {
         pendingWidgetRoute = route
+    }
+
+    fun markPermissionAsked() {
+        _uiState.update { it.copy(permissionAsked = true) }
+    }
+
+    fun onPermissionResult() {
+        _uiState.update { it.copy(permissionHandled = true) }
+    }
+
+    fun markSchedulersSetUp() {
+        _uiState.update { it.copy(schedulersSetUp = true) }
     }
 
     fun checkNetworkAndProceed() {

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsScreen.kt
@@ -17,11 +17,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -48,29 +44,25 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun StatisticsScreen(
     viewModel: StatisticsViewModel = hiltViewModel(),
-    initialPreset: DateRangePreset = DateRangePreset.WEEK
+    initialPreset: DateRangePreset = DateRangePreset.WEEK,
 ) {
     val scrollState = rememberLazyListState()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    var showPicker by remember { mutableStateOf(false) }
-    var presetIndex by rememberSaveable { mutableIntStateOf(initialPreset.ordinal) }
-    val preset = presetFromIndex(presetIndex)
-    val rangeText = remember(presetIndex) { formatRange(preset) }
-    val title = remember(presetIndex) { pagesTitle(preset) }
+    val preset = presetFromIndex(uiState.selectedPresetIndex)
+    val rangeText = remember(uiState.selectedPresetIndex) { formatRange(preset) }
+    val title = remember(uiState.selectedPresetIndex) { pagesTitle(preset) }
 
-    LaunchedEffect(initialPreset) { viewModel.loadStatistics(initialPreset) }
+    LaunchedEffect(initialPreset) {
+        viewModel.loadStatistics(initialPreset)
+    }
 
-    if (showPicker) {
+    if (uiState.showPicker) {
         StatisticsPicker(
-            initialIndex = presetIndex,
+            initialIndex = uiState.selectedPresetIndex,
             items = STAT_PRESET_LABELS,
-            onDismiss = { showPicker = false },
-            onConfirm = { index ->
-                presetIndex = index
-                showPicker = false
-                viewModel.loadStatistics(presetFromIndex(index))
-            },
-            infiniteScroll = false
+            onDismiss = { viewModel.hidePicker() },
+            onConfirm = { index -> viewModel.setPreset(index) },
+            infiniteScroll = false,
         )
     }
 
@@ -78,13 +70,13 @@ fun StatisticsScreen(
         modifier = Modifier.fillMaxSize(),
         state = scrollState,
         contentPadding = PaddingValues(vertical = 20.dp, horizontal = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
+        verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
         item {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Semi14Text(
                     text = rangeText,
-                    color = GureumTheme.colors.gray700
+                    color = GureumTheme.colors.gray700,
                 )
                 Spacer(modifier = Modifier.weight(1f))
 
@@ -93,17 +85,17 @@ fun StatisticsScreen(
                         .clickable(
                             indication = null,
                             interactionSource = remember { MutableInteractionSource() },
-                            onClick = { showPicker = true },
+                            onClick = { viewModel.showPicker() },
                         ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Semi16Text(STAT_PRESET_LABELS[presetIndex], color = GureumTheme.colors.gray700)
+                    Semi16Text(STAT_PRESET_LABELS[uiState.selectedPresetIndex], color = GureumTheme.colors.gray700)
                     Spacer(Modifier.width(8.dp))
                     Icon(
                         painter = painterResource(R.drawable.ic_arrow_down),
                         contentDescription = null,
                         modifier = Modifier.size(28.dp),
-                        tint = GureumTheme.colors.gray800
+                        tint = GureumTheme.colors.gray800,
                     )
                 }
             }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsScreen.kt
@@ -62,7 +62,7 @@ fun StatisticsScreen(
         xLabels = uiState.xLabels,
         hasError = uiState.hasError,
         showPicker = uiState.showPicker,
-        selectedPresetIndex = uiState.selectedPresetIndex,
+        selectedPreset = uiState.selectedPreset,
         onShowPicker = viewModel::showPicker,
         onHidePicker = viewModel::hidePicker,
         onSetPreset = viewModel::setPreset,
@@ -77,22 +77,21 @@ private fun StatisticsContent(
     xLabels: List<String>,
     hasError: Boolean,
     showPicker: Boolean,
-    selectedPresetIndex: Int,
+    selectedPreset: DateRangePreset,
     onShowPicker: () -> Unit,
     onHidePicker: () -> Unit,
-    onSetPreset: (Int) -> Unit,
+    onSetPreset: (DateRangePreset) -> Unit,
 ) {
     val scrollState = rememberLazyListState()
-    val preset = presetFromIndex(selectedPresetIndex)
-    val rangeText = remember(selectedPresetIndex) { formatRange(preset) }
-    val title = remember(selectedPresetIndex) { pagesTitle(preset) }
+    val rangeText = remember(selectedPreset) { formatRange(selectedPreset) }
+    val title = remember(selectedPreset) { pagesTitle(selectedPreset) }
 
     if (showPicker) {
         StatisticsPicker(
-            initialIndex = selectedPresetIndex,
+            initialIndex = DateRangePreset.entries.indexOf(selectedPreset).coerceAtLeast(0),
             items = STAT_PRESET_LABELS,
             onDismiss = onHidePicker,
-            onConfirm = onSetPreset,
+            onConfirm = { index -> onSetPreset(DateRangePreset.entries.getOrElse(index) { DateRangePreset.WEEK }) },
             infiniteScroll = false,
         )
     }
@@ -120,7 +119,10 @@ private fun StatisticsContent(
                         ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Semi16Text(STAT_PRESET_LABELS[selectedPresetIndex], color = GureumTheme.colors.gray700)
+                    Semi16Text(
+                        STAT_PRESET_LABELS[DateRangePreset.entries.indexOf(selectedPreset).coerceAtLeast(0)],
+                        color = GureumTheme.colors.gray700,
+                    )
                     Spacer(Modifier.width(8.dp))
                     Icon(
                         painter = painterResource(R.drawable.ic_arrow_down),
@@ -178,14 +180,6 @@ private fun pagesTitle(preset: DateRangePreset) = when (preset) {
     DateRangePreset.YEAR -> "연간 독서 페이지"
 }
 
-private fun presetFromIndex(index: Int) = when (index) {
-    0 -> DateRangePreset.WEEK
-    1 -> DateRangePreset.MONTH
-    2 -> DateRangePreset.THREE_MONTH
-    3 -> DateRangePreset.SIX_MONTH
-    else -> DateRangePreset.YEAR
-}
-
 private val STAT_PRESET_LABELS = listOf("1주", "1개월", "3개월", "6개월", "1년")
 
 @Preview(name = "Empty - Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
@@ -200,7 +194,7 @@ private fun StatisticsEmptyPreview() {
             xLabels = emptyList(),
             hasError = false,
             showPicker = false,
-            selectedPresetIndex = 0,
+            selectedPreset = DateRangePreset.WEEK,
             onShowPicker = {},
             onHidePicker = {},
             onSetPreset = {},
@@ -216,7 +210,7 @@ private fun StatisticsWithDataPreview() {
         PieEntry(40f, "소설"),
         PieEntry(30f, "자기계발"),
         PieEntry(20f, "경제"),
-        PieEntry(10f, "기타")
+        PieEntry(10f, "기타"),
     )
     val sampleTime = listOf(
         BarEntry(0f, 30f),
@@ -225,7 +219,7 @@ private fun StatisticsWithDataPreview() {
         BarEntry(3f, 60f),
         BarEntry(4f, 20f),
         BarEntry(5f, 0f),
-        BarEntry(6f, 15f)
+        BarEntry(6f, 15f),
     )
     val samplePages = listOf(
         Entry(0f, 100f),
@@ -234,7 +228,7 @@ private fun StatisticsWithDataPreview() {
         Entry(3f, 200f),
         Entry(4f, 180f),
         Entry(5f, 250f),
-        Entry(6f, 220f)
+        Entry(6f, 220f),
     )
     val sampleXLabels = listOf("월", "화", "수", "목", "금", "토", "일")
 
@@ -246,7 +240,7 @@ private fun StatisticsWithDataPreview() {
             xLabels = sampleXLabels,
             hasError = false,
             showPicker = false,
-            selectedPresetIndex = 0,
+            selectedPreset = DateRangePreset.WEEK,
             onShowPicker = {},
             onHidePicker = {},
             onSetPreset = {},

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsScreen.kt
@@ -25,6 +25,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.github.mikephil.charting.data.BarEntry
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.PieEntry
 import com.hihihihi.domain.model.DateRange
 import com.hihihihi.domain.model.DateRangePreset
 import com.hihihihi.domain.usecase.statistics.presetToRange
@@ -46,22 +49,50 @@ fun StatisticsScreen(
     viewModel: StatisticsViewModel = hiltViewModel(),
     initialPreset: DateRangePreset = DateRangePreset.WEEK,
 ) {
-    val scrollState = rememberLazyListState()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val preset = presetFromIndex(uiState.selectedPresetIndex)
-    val rangeText = remember(uiState.selectedPresetIndex) { formatRange(preset) }
-    val title = remember(uiState.selectedPresetIndex) { pagesTitle(preset) }
 
     LaunchedEffect(initialPreset) {
         viewModel.loadStatistics(initialPreset)
     }
 
-    if (uiState.showPicker) {
+    StatisticsContent(
+        category = uiState.category,
+        time = uiState.time,
+        pages = uiState.pages,
+        xLabels = uiState.xLabels,
+        hasError = uiState.hasError,
+        showPicker = uiState.showPicker,
+        selectedPresetIndex = uiState.selectedPresetIndex,
+        onShowPicker = viewModel::showPicker,
+        onHidePicker = viewModel::hidePicker,
+        onSetPreset = viewModel::setPreset,
+    )
+}
+
+@Composable
+private fun StatisticsContent(
+    category: List<PieEntry>,
+    time: List<BarEntry>,
+    pages: List<Entry>,
+    xLabels: List<String>,
+    hasError: Boolean,
+    showPicker: Boolean,
+    selectedPresetIndex: Int,
+    onShowPicker: () -> Unit,
+    onHidePicker: () -> Unit,
+    onSetPreset: (Int) -> Unit,
+) {
+    val scrollState = rememberLazyListState()
+    val preset = presetFromIndex(selectedPresetIndex)
+    val rangeText = remember(selectedPresetIndex) { formatRange(preset) }
+    val title = remember(selectedPresetIndex) { pagesTitle(preset) }
+
+    if (showPicker) {
         StatisticsPicker(
-            initialIndex = uiState.selectedPresetIndex,
+            initialIndex = selectedPresetIndex,
             items = STAT_PRESET_LABELS,
-            onDismiss = { viewModel.hidePicker() },
-            onConfirm = { index -> viewModel.setPreset(index) },
+            onDismiss = onHidePicker,
+            onConfirm = onSetPreset,
             infiniteScroll = false,
         )
     }
@@ -85,11 +116,11 @@ fun StatisticsScreen(
                         .clickable(
                             indication = null,
                             interactionSource = remember { MutableInteractionSource() },
-                            onClick = { viewModel.showPicker() },
+                            onClick = onShowPicker,
                         ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Semi16Text(STAT_PRESET_LABELS[uiState.selectedPresetIndex], color = GureumTheme.colors.gray700)
+                    Semi16Text(STAT_PRESET_LABELS[selectedPresetIndex], color = GureumTheme.colors.gray700)
                     Spacer(Modifier.width(8.dp))
                     Icon(
                         painter = painterResource(R.drawable.ic_arrow_down),
@@ -105,9 +136,9 @@ fun StatisticsScreen(
             Semi16Text("독서 장르 분포")
             Spacer(modifier = Modifier.height(12.dp))
             when {
-                uiState.hasError -> EmptyCard("통계를 불러올 수 없습니다", "잠시 후 다시 시도해주세요")
-                uiState.category.isEmpty() -> EmptyCard()
-                else -> CategoryCard(entries = uiState.category)
+                hasError -> EmptyCard("통계를 불러올 수 없습니다", "잠시 후 다시 시도해주세요")
+                category.isEmpty() -> EmptyCard()
+                else -> CategoryCard(entries = category)
             }
         }
 
@@ -115,9 +146,9 @@ fun StatisticsScreen(
             Semi16Text("독서 시간 분포")
             Spacer(modifier = Modifier.height(12.dp))
             when {
-                uiState.hasError -> EmptyCard("통계를 불러올 수 없습니다", "잠시 후 다시 시도해주세요")
-                uiState.time.isEmpty() || uiState.time.all { it.y == 0f } -> EmptyCard(subText = "새 기록을 추가하면 추이가 표시돼요.")
-                else -> ReadingTimeCard(entries = uiState.time)
+                hasError -> EmptyCard("통계를 불러올 수 없습니다", "잠시 후 다시 시도해주세요")
+                time.isEmpty() || time.all { it.y == 0f } -> EmptyCard(subText = "새 기록을 추가하면 추이가 표시돼요.")
+                else -> ReadingTimeCard(entries = time)
             }
         }
 
@@ -125,9 +156,9 @@ fun StatisticsScreen(
             Semi16Text(title)
             Spacer(modifier = Modifier.height(12.dp))
             when {
-                uiState.hasError -> EmptyCard("통계를 불러올 수 없습니다", "잠시 후 다시 시도해주세요")
-                uiState.pages.isEmpty() || uiState.pages.all { it.y == 0f } -> EmptyCard(subText = "책을 읽고 페이지를 기록해 주세요.")
-                else -> ReadingPageCard(entries = uiState.pages, xLabels = uiState.xLabels)
+                hasError -> EmptyCard("통계를 불러올 수 없습니다", "잠시 후 다시 시도해주세요")
+                pages.isEmpty() || pages.all { it.y == 0f } -> EmptyCard(subText = "책을 읽고 페이지를 기록해 주세요.")
+                else -> ReadingPageCard(entries = pages, xLabels = xLabels)
             }
         }
     }
@@ -157,11 +188,68 @@ private fun presetFromIndex(index: Int) = when (index) {
 
 private val STAT_PRESET_LABELS = listOf("1주", "1개월", "3개월", "6개월", "1년")
 
-@Preview(name = "Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
-@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "Empty - Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Empty - Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-private fun StatisticsPreview() {
+private fun StatisticsEmptyPreview() {
     GureumPageTheme {
-        StatisticsScreen()
+        StatisticsContent(
+            category = emptyList(),
+            time = emptyList(),
+            pages = emptyList(),
+            xLabels = emptyList(),
+            hasError = false,
+            showPicker = false,
+            selectedPresetIndex = 0,
+            onShowPicker = {},
+            onHidePicker = {},
+            onSetPreset = {},
+        )
+    }
+}
+
+@Preview(name = "WithData - Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "WithData - Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun StatisticsWithDataPreview() {
+    val sampleCategory = listOf(
+        PieEntry(40f, "소설"),
+        PieEntry(30f, "자기계발"),
+        PieEntry(20f, "경제"),
+        PieEntry(10f, "기타")
+    )
+    val sampleTime = listOf(
+        BarEntry(0f, 30f),
+        BarEntry(1f, 45f),
+        BarEntry(2f, 10f),
+        BarEntry(3f, 60f),
+        BarEntry(4f, 20f),
+        BarEntry(5f, 0f),
+        BarEntry(6f, 15f)
+    )
+    val samplePages = listOf(
+        Entry(0f, 100f),
+        Entry(1f, 150f),
+        Entry(2f, 120f),
+        Entry(3f, 200f),
+        Entry(4f, 180f),
+        Entry(5f, 250f),
+        Entry(6f, 220f)
+    )
+    val sampleXLabels = listOf("월", "화", "수", "목", "금", "토", "일")
+
+    GureumPageTheme {
+        StatisticsContent(
+            category = sampleCategory,
+            time = sampleTime,
+            pages = samplePages,
+            xLabels = sampleXLabels,
+            hasError = false,
+            showPicker = false,
+            selectedPresetIndex = 0,
+            onShowPicker = {},
+            onHidePicker = {},
+            onSetPreset = {},
+        )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsUiState.kt
@@ -3,6 +3,7 @@ package com.hihihihi.presentation.ui.statistics
 import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.data.PieEntry
+import com.hihihihi.domain.model.DateRangePreset
 
 data class StatisticsUiState(
     val category: List<PieEntry> = emptyList(),
@@ -12,5 +13,5 @@ data class StatisticsUiState(
     val hasError: Boolean = false,
     val errorMessage: String = "",
     val showPicker: Boolean = false,
-    val selectedPresetIndex: Int = 0,
+    val selectedPreset: DateRangePreset = DateRangePreset.WEEK,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsUiState.kt
@@ -10,5 +10,7 @@ data class StatisticsUiState(
     val pages: List<Entry> = emptyList(),
     val xLabels: List<String> = emptyList(),
     val hasError: Boolean = false,
-    val errorMessage: String = ""
+    val errorMessage: String = "",
+    val showPicker: Boolean = false,
+    val selectedPresetIndex: Int = 0,
 )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsViewModel.kt
@@ -12,13 +12,14 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class StatisticsViewModel @Inject constructor(
     private val getStatisticsUseCase: GetStatisticsUseCase,
-    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase
+    private val getCurrentUserIdUseCase: GetCurrentUserIdUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(StatisticsUiState())
     val uiState: StateFlow<StatisticsUiState> = _uiState
@@ -32,25 +33,49 @@ class StatisticsViewModel @Inject constructor(
         }
     }
 
+    fun showPicker() {
+        _uiState.update { it.copy(showPicker = true) }
+    }
+
+    fun hidePicker() {
+        _uiState.update { it.copy(showPicker = false) }
+    }
+
+    fun setPreset(index: Int) {
+        _uiState.update { it.copy(selectedPresetIndex = index, showPicker = false) }
+        loadStatistics(presetFromIndex(index))
+    }
+
     fun loadStatistics(preset: DateRangePreset) {
         if (userId == null) return
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 getStatisticsUseCase(userId, preset).collect { statistics ->
-                    _uiState.value = StatisticsUiState(
-                        category = statistics.category.map { PieEntry(it.value, it.label) },
-                        time = statistics.time.asReversed()
-                            .mapIndexed { index, slice -> BarEntry(index.toFloat(), slice.value) },
-                        pages = statistics.pages.map { Entry(it.x, it.y) },
-                        xLabels = statistics.xLabels,
-                    )
+                    _uiState.update { current ->
+                        current.copy(
+                            category = statistics.category.map { PieEntry(it.value, it.label) },
+                            time = statistics.time.asReversed()
+                                .mapIndexed { index, slice -> BarEntry(index.toFloat(), slice.value) },
+                            pages = statistics.pages.map { Entry(it.x, it.y) },
+                            xLabels = statistics.xLabels,
+                            hasError = false,
+                            errorMessage = "",
+                        )
+                    }
                 }
             } catch (e: Exception) {
-                _uiState.value = StatisticsUiState(
-                    hasError = true,
-                    errorMessage = "통계를 불러올 수 없습니다"
-                )
+                _uiState.update { current ->
+                    current.copy(hasError = true, errorMessage = "통계를 불러올 수 없습니다")
+                }
             }
         }
+    }
+
+    private fun presetFromIndex(index: Int) = when (index) {
+        0 -> DateRangePreset.WEEK
+        1 -> DateRangePreset.MONTH
+        2 -> DateRangePreset.THREE_MONTH
+        3 -> DateRangePreset.SIX_MONTH
+        else -> DateRangePreset.YEAR
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/statistics/StatisticsViewModel.kt
@@ -26,7 +26,6 @@ class StatisticsViewModel @Inject constructor(
 
     val userId: String? = getCurrentUserIdUseCase()
 
-
     init {
         if (userId != null) {
             loadStatistics(DateRangePreset.WEEK)
@@ -41,9 +40,9 @@ class StatisticsViewModel @Inject constructor(
         _uiState.update { it.copy(showPicker = false) }
     }
 
-    fun setPreset(index: Int) {
-        _uiState.update { it.copy(selectedPresetIndex = index, showPicker = false) }
-        loadStatistics(presetFromIndex(index))
+    fun setPreset(preset: DateRangePreset) {
+        _uiState.update { it.copy(selectedPreset = preset, showPicker = false) }
+        loadStatistics(preset)
     }
 
     fun loadStatistics(preset: DateRangePreset) {
@@ -69,13 +68,5 @@ class StatisticsViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    private fun presetFromIndex(index: Int) = when (index) {
-        0 -> DateRangePreset.WEEK
-        1 -> DateRangePreset.MONTH
-        2 -> DateRangePreset.THREE_MONTH
-        3 -> DateRangePreset.SIX_MONTH
-        else -> DateRangePreset.YEAR
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerEvents.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerEvents.kt
@@ -1,0 +1,15 @@
+package com.hihihihi.presentation.ui.timer
+
+sealed class TimerDialogState {
+    object None : TimerDialogState()
+    object Memo : TimerDialogState()
+    data class StopConfirm(val wasRunning: Boolean) : TimerDialogState()
+    data class BackExit(val wasRunning: Boolean) : TimerDialogState()
+}
+
+enum class TimerDialogType { Memo, StopConfirm, BackExit }
+
+sealed class TimerEffect {
+    object RequestOverlayPermission : TimerEffect()
+    object StartFloatingWindow : TimerEffect()
+}

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
@@ -23,12 +23,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,6 +38,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.bookdetail.components.AddQuoteDialog
 import com.hihihihi.presentation.ui.timer.component.CountdownOverlayWithHole
@@ -67,14 +66,6 @@ fun TimerScreen(
     val memoState by memoViewModel.ui.collectAsStateWithLifecycle()
     val sharedTimerState by viewModel.sharedTimerState.collectAsStateWithLifecycle()
 
-    // 정지 확인 다이얼로그 상태
-    var showStopDialog by rememberSaveable { mutableStateOf(false) }
-    var wasRunningBeforeDialog by rememberSaveable { mutableStateOf(false) }
-
-    // 필사 다이얼로그 - showMemoDialog 상태 사용
-    var showBackExitScreen by rememberSaveable { mutableStateOf(false) }
-    var wasRunningBeforeBack by rememberSaveable { mutableStateOf(false) }
-
     var overlayRectWin by remember { mutableStateOf<Rect?>(null) }
     var cardRectWin by remember { mutableStateOf<Rect?>(null) }
 
@@ -85,9 +76,9 @@ fun TimerScreen(
                 val c = cardRectWin!!
                 Rect(
                     offset = Offset(c.left - o.left, c.top - o.top),
-                    size = c.size
+                    size = c.size,
                 )
-            } else null
+            } else null,
         )
     }
 
@@ -105,8 +96,8 @@ fun TimerScreen(
     LaunchedEffect(userBookId) {
         viewModel.bind(userBookId)
         memoViewModel.clear()
-        showBackExitScreen = false
-        showStopDialog = false
+        viewModel.dismissBackExitScreen(resumeTimer = false)
+        viewModel.dismissStopDialog(resumeTimer = false)
     }
 
     val appBarUp = LocalAppBarUpClick.current
@@ -116,32 +107,28 @@ fun TimerScreen(
         if (state.countdown != null) return@LaunchedEffect
         if (appBarUp != 0L && appBarUp != lastHandledUpTs) {
             lastHandledUpTs = appBarUp
-            wasRunningBeforeBack = state.isRunning
-            if (state.isRunning) viewModel.pause()
-            showBackExitScreen = true
+            viewModel.requestBackExitScreen(wasRunning = state.isRunning)
         }
     }
 
     // 하드웨어 뒤로가기
     BackHandler(
-        enabled = state.countdown == null && !showStopDialog && !state.showMemoDialog && !showBackExitScreen
+        enabled = state.countdown == null && !state.showStopDialog && !state.showMemoDialog && !state.showBackExitScreen,
     ) {
-        wasRunningBeforeBack = state.isRunning
-        if (state.isRunning) viewModel.pause()
-        showBackExitScreen = true
+        viewModel.requestBackExitScreen(wasRunning = state.isRunning)
     }
 
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(colors.background)
-            .onGloballyPositioned { overlayRectWin = it.boundsInWindow() }
+            .onGloballyPositioned { overlayRectWin = it.boundsInWindow() },
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(Modifier.height(24.dp))
 
@@ -154,7 +141,7 @@ fun TimerScreen(
                     .fillMaxWidth()
                     .onGloballyPositioned { coords ->
                         cardRectWin = coords.boundsInWindow()
-                    }
+                    },
             )
 
             Spacer(Modifier.height(24.dp))
@@ -162,7 +149,7 @@ fun TimerScreen(
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
+                horizontalArrangement = Arrangement.End,
             ) {
                 IconButton(
                     onClick = {
@@ -172,7 +159,7 @@ fun TimerScreen(
                             if (!Settings.canDrawOverlays(context)) {
                                 val intent = Intent(
                                     Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                                    "package:${context.packageName}".toUri()
+                                    "package:${context.packageName}".toUri(),
                                 )
                                 context.startActivity(intent)
                                 return@IconButton
@@ -182,13 +169,13 @@ fun TimerScreen(
                         viewModel.startFloatingWindowMode(context)
                         (context as? Activity)?.moveTaskToBack(true)
                     },
-                    modifier = Modifier.size(36.dp)
+                    modifier = Modifier.size(36.dp),
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.OpenInNew,
                         contentDescription = "플로팅 모드",
                         tint = colors.gray300,
-                        modifier = Modifier.size(32.dp)
+                        modifier = Modifier.size(32.dp),
                     )
                 }
             }
@@ -201,7 +188,7 @@ fun TimerScreen(
                     .size(240.dp)
                     .offset(y = 12.dp),
                 isRunning = state.isRunning,
-                centerText = state.countdown?.toString() ?: state.displayTimeMMSS
+                centerText = state.countdown?.toString() ?: state.displayTimeMMSS,
             )
 
             Spacer(Modifier.height(40.dp))
@@ -217,7 +204,7 @@ fun TimerScreen(
                 lines = lines,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f)
+                    .weight(1f),
             )
 
             Spacer(Modifier.height(16.dp))
@@ -231,14 +218,12 @@ fun TimerScreen(
                 },
                 onStop = {
                     if (state.countdown != null) return@TimerControlsRow
-                    wasRunningBeforeDialog = state.isRunning
-                    if (state.isRunning) viewModel.pause()
-                    showStopDialog = true
+                    viewModel.requestStopDialog(wasRunning = state.isRunning)
                 },
                 onEdit = {
                     if (state.countdown != null) return@TimerControlsRow
                     viewModel.showMemoDialog()
-                }
+                },
             )
 
             Spacer(Modifier.height(32.dp))
@@ -249,28 +234,25 @@ fun TimerScreen(
                 number = state.countdown!!,
                 holeRect = cardRectForOverlay,
                 holeCornerRadiusDp = 16f,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier.fillMaxSize(),
             )
         }
 
         // 정지 확인 다이얼로그
-        if (showStopDialog) {
+        if (state.showStopDialog) {
             StopReadingDialog(
                 displayTime = state.displayTimeMMSS,
                 title = state.bookTitle,
                 author = state.author,
                 currentPage = state.startPage,
                 totalPage = state.totalPage,
-                onConfirmStop = { showStopDialog = false },
-                onDismiss = {
-                    showStopDialog = false
-                    if (wasRunningBeforeDialog) viewModel.start()
-                },
+                onConfirmStop = { viewModel.dismissStopDialog(resumeTimer = false) },
+                onDismiss = { viewModel.dismissStopDialog(resumeTimer = true) },
                 onConfirmStopPages = { s, e ->
                     viewModel.finishAndSave(userBookId, s, e)
-                    showStopDialog = false
+                    viewModel.dismissStopDialog(resumeTimer = false)
                     onExit()
-                }
+                },
             )
         }
 
@@ -292,26 +274,23 @@ fun TimerScreen(
                         viewModel.dismissMemoDialog()
                     }
                 },
-                lastPage = state.totalPage
+                lastPage = state.totalPage,
             )
         }
 
         // 뒤로가기 다이얼로그
-        if (showBackExitScreen) {
+        if (state.showBackExitScreen) {
             StopReadingConfirmDialog(
                 displayTime = state.displayTimeMMSS,
                 title = state.bookTitle,
                 author = state.author,
                 willSave = false,
-                onContinue = {
-                    showBackExitScreen = false
-                    if (wasRunningBeforeBack) viewModel.start()
-                },
+                onContinue = { viewModel.dismissBackExitScreen(resumeTimer = true) },
                 onStop = {
                     viewModel.stop()
-                    showBackExitScreen = false
+                    viewModel.dismissBackExitScreen(resumeTimer = false)
                     onExit()
-                }
+                },
             )
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -63,9 +63,9 @@ fun TimerScreen(
     val context = LocalContext.current
 
     // UI 상태 수집
-    val state by viewModel.uiState.collectAsState()
-    val memoState by memoViewModel.ui.collectAsState()
-    val sharedTimerState by viewModel.sharedTimerState.collectAsState()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val memoState by memoViewModel.ui.collectAsStateWithLifecycle()
+    val sharedTimerState by viewModel.sharedTimerState.collectAsStateWithLifecycle()
 
     // 정지 확인 다이얼로그 상태
     var showStopDialog by rememberSaveable { mutableStateOf(false) }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
@@ -41,7 +41,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.bookdetail.components.AddQuoteDialog
@@ -66,9 +69,33 @@ fun TimerScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val memoState by memoViewModel.ui.collectAsStateWithLifecycle()
 
+    val lifecycleOwner = LocalLifecycleOwner.current
+
     LaunchedEffect(Unit) {
         viewModel.ensureFloatingWindowClosed(context)
         viewModel.resumeIfNeeded()
+    }
+
+    // 오버레이 권한 요청 / 플로팅 윈도우 시작
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.effect.collect { effect ->
+                when (effect) {
+                    TimerEffect.RequestOverlayPermission -> {
+                        val intent = Intent(
+                            Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                            "package:${context.packageName}".toUri(),
+                        )
+                        context.startActivity(intent)
+                    }
+
+                    TimerEffect.StartFloatingWindow -> {
+                        viewModel.startFloatingWindowMode(context)
+                        (context as? Activity)?.moveTaskToBack(true)
+                    }
+                }
+            }
+        }
     }
 
     LaunchedEffect(state.showMemoDialog) {
@@ -80,8 +107,7 @@ fun TimerScreen(
     LaunchedEffect(userBookId) {
         viewModel.bind(userBookId)
         memoViewModel.clear()
-        viewModel.dismissBackExitScreen(resumeTimer = false)
-        viewModel.dismissStopDialog(resumeTimer = false)
+        viewModel.dismissDialog()
     }
 
     val appBarUp = LocalAppBarUpClick.current
@@ -91,14 +117,14 @@ fun TimerScreen(
         if (state.countdown != null) return@LaunchedEffect
         if (appBarUp != 0L && appBarUp != lastHandledUpTs) {
             lastHandledUpTs = appBarUp
-            viewModel.requestBackExitScreen(wasRunning = state.isRunning)
+            viewModel.showDialog(TimerDialogType.BackExit)
         }
     }
 
     BackHandler(
         enabled = state.countdown == null && !state.showStopDialog && !state.showMemoDialog && !state.showBackExitScreen,
     ) {
-        viewModel.requestBackExitScreen(wasRunning = state.isRunning)
+        viewModel.showDialog(TimerDialogType.BackExit)
     }
 
     val memoLines = remember(memoState.items, userBookId) {
@@ -121,21 +147,19 @@ fun TimerScreen(
         showBackExitScreen = state.showBackExitScreen,
         memoLines = memoLines,
         onToggle = viewModel::toggleRun,
-        onRequestStopDialog = { viewModel.requestStopDialog(wasRunning = state.isRunning) },
-        onDismissStopDialog = viewModel::dismissStopDialog,
+        onRequestStopDialog = { viewModel.showDialog(TimerDialogType.StopConfirm) },
+        onDismissDialog = viewModel::dismissDialog,
         onConfirmStopAndExit = { s, e ->
             viewModel.finishAndSave(userBookId, s, e)
-            viewModel.dismissStopDialog(resumeTimer = false)
+            viewModel.dismissDialog()
             onExit()
         },
-        onDismissBackExitScreen = viewModel::dismissBackExitScreen,
         onStopAndExit = {
             viewModel.stop()
-            viewModel.dismissBackExitScreen(resumeTimer = false)
+            viewModel.dismissDialog()
             onExit()
         },
-        onShowMemoDialog = viewModel::showMemoDialog,
-        onDismissMemoDialog = viewModel::dismissMemoDialog,
+        onShowMemoDialog = { viewModel.showDialog(TimerDialogType.Memo) },
         onSaveMemo = { page, content ->
             memoViewModel.add(
                 userBookId = userBookId,
@@ -144,19 +168,11 @@ fun TimerScreen(
                 title = state.bookTitle,
                 author = state.author,
                 imageUrl = state.bookImageUrl,
-            ) { viewModel.dismissMemoDialog() }
+            ) { viewModel.dismissDialog() }
         },
         onOpenFloatingMode = {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                val ctx = context
-                if (!Settings.canDrawOverlays(ctx)) {
-                    val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, "package:${ctx.packageName}".toUri())
-                    ctx.startActivity(intent)
-                    return@TimerContent
-                }
-            }
-            viewModel.startFloatingWindowMode(context)
-            (context as? Activity)?.moveTaskToBack(true)
+            val canDraw = Build.VERSION.SDK_INT < Build.VERSION_CODES.M || Settings.canDrawOverlays(context)
+            viewModel.openFloatingMode(canDraw)
         },
     )
 }
@@ -177,12 +193,10 @@ private fun TimerContent(
     memoLines: List<String>,
     onToggle: () -> Unit,
     onRequestStopDialog: () -> Unit,
-    onDismissStopDialog: (resumeTimer: Boolean) -> Unit,
+    onDismissDialog: (resumeTimer: Boolean) -> Unit,
     onConfirmStopAndExit: (startPage: Int, endPage: Int) -> Unit,
-    onDismissBackExitScreen: (resumeTimer: Boolean) -> Unit,
     onStopAndExit: () -> Unit,
     onShowMemoDialog: () -> Unit,
-    onDismissMemoDialog: () -> Unit,
     onSaveMemo: (page: String?, content: String) -> Unit,
     onOpenFloatingMode: () -> Unit,
 ) {
@@ -205,7 +219,9 @@ private fun TimerContent(
             .onGloballyPositioned { overlayRectWin = it.boundsInWindow() },
     ) {
         Column(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(Modifier.height(24.dp))
@@ -214,7 +230,9 @@ private fun TimerContent(
                 title = bookTitle,
                 author = author,
                 imageUrl = bookImageUrl,
-                modifier = Modifier.fillMaxWidth().onGloballyPositioned { cardRectWin = it.boundsInWindow() },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onGloballyPositioned { cardRectWin = it.boundsInWindow() },
             )
 
             Spacer(Modifier.height(24.dp))
@@ -239,14 +257,21 @@ private fun TimerContent(
             Spacer(Modifier.height(8.dp))
 
             TimerRing(
-                modifier = Modifier.size(240.dp).offset(y = 12.dp),
+                modifier = Modifier
+                    .size(240.dp)
+                    .offset(y = 12.dp),
                 isRunning = isRunning,
                 centerText = countdown?.toString() ?: displayTimeMMSS,
             )
 
             Spacer(Modifier.height(40.dp))
 
-            MemoList(lines = memoLines, modifier = Modifier.fillMaxWidth().weight(1f))
+            MemoList(
+                lines = memoLines,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            )
 
             Spacer(Modifier.height(16.dp))
 
@@ -285,15 +310,15 @@ private fun TimerContent(
                 author = author,
                 currentPage = startPage,
                 totalPage = totalPage,
-                onConfirmStop = { onDismissStopDialog(false) },
-                onDismiss = { onDismissStopDialog(true) },
+                onConfirmStop = { onDismissDialog(false) },
+                onDismiss = { onDismissDialog(true) },
                 onConfirmStopPages = { s, e -> onConfirmStopAndExit(s, e) },
             )
         }
 
         if (showMemoDialog) {
             AddQuoteDialog(
-                onDismiss = onDismissMemoDialog,
+                onDismiss = { onDismissDialog(false) },
                 onSave = { page, content ->
                     onSaveMemo(page, content)
                 },
@@ -307,7 +332,7 @@ private fun TimerContent(
                 title = bookTitle,
                 author = author,
                 willSave = false,
-                onContinue = { onDismissBackExitScreen(true) },
+                onContinue = { onDismissDialog(true) },
                 onStop = onStopAndExit,
             )
         }
@@ -334,12 +359,10 @@ private fun TimerPreview() {
             memoLines = listOf("#1 - 인상깊은 문장"),
             onToggle = {},
             onRequestStopDialog = {},
-            onDismissStopDialog = {},
+            onDismissDialog = {},
             onConfirmStopAndExit = { _, _ -> },
-            onDismissBackExitScreen = {},
             onStopAndExit = {},
             onShowMemoDialog = {},
-            onDismissMemoDialog = {},
             onSaveMemo = { _, _ -> },
             onOpenFloatingMode = {},
         )

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -189,14 +190,12 @@ private fun TimerContent(
 
     var overlayRectWin by remember { mutableStateOf<Rect?>(null) }
     var cardRectWin by remember { mutableStateOf<Rect?>(null) }
-    val cardRectForOverlay by remember(overlayRectWin, cardRectWin) {
-        mutableStateOf(
-            if (overlayRectWin != null && cardRectWin != null) {
-                val o = overlayRectWin!!
-                val c = cardRectWin!!
-                Rect(offset = Offset(c.left - o.left, c.top - o.top), size = c.size)
-            } else null,
-        )
+    val cardRectForOverlay by remember {
+        derivedStateOf {
+            val o = overlayRectWin ?: return@derivedStateOf null
+            val c = cardRectWin ?: return@derivedStateOf null
+            Rect(offset = Offset(c.left - o.left, c.top - o.top), size = c.size)
+        }
     }
 
     Box(

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerScreen.kt
@@ -2,6 +2,7 @@ package com.hihihihi.presentation.ui.timer
 
 import android.app.Activity
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Build
 import android.provider.Settings
 import androidx.activity.compose.BackHandler
@@ -35,10 +36,12 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.ui.bookdetail.components.AddQuoteDialog
 import com.hihihihi.presentation.ui.timer.component.CountdownOverlayWithHole
@@ -58,29 +61,9 @@ fun TimerScreen(
     viewModel: TimerViewModel = hiltViewModel(),
     memoViewModel: MemoViewModel = hiltViewModel(),
 ) {
-    val colors = GureumTheme.colors
     val context = LocalContext.current
-
-    // UI 상태 수집
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val memoState by memoViewModel.ui.collectAsStateWithLifecycle()
-    val sharedTimerState by viewModel.sharedTimerState.collectAsStateWithLifecycle()
-
-    var overlayRectWin by remember { mutableStateOf<Rect?>(null) }
-    var cardRectWin by remember { mutableStateOf<Rect?>(null) }
-
-    val cardRectForOverlay by remember(overlayRectWin, cardRectWin) {
-        mutableStateOf(
-            if (overlayRectWin != null && cardRectWin != null) {
-                val o = overlayRectWin!!
-                val c = cardRectWin!!
-                Rect(
-                    offset = Offset(c.left - o.left, c.top - o.top),
-                    size = c.size,
-                )
-            } else null,
-        )
-    }
 
     LaunchedEffect(Unit) {
         viewModel.ensureFloatingWindowClosed(context)
@@ -111,11 +94,109 @@ fun TimerScreen(
         }
     }
 
-    // 하드웨어 뒤로가기
     BackHandler(
         enabled = state.countdown == null && !state.showStopDialog && !state.showMemoDialog && !state.showBackExitScreen,
     ) {
         viewModel.requestBackExitScreen(wasRunning = state.isRunning)
+    }
+
+    val memoLines = remember(memoState.items, userBookId) {
+        memoState.items
+            .filter { it.userBookId == userBookId }
+            .mapIndexed { idx, q -> "#${idx + 1} - ${q.content}" }
+    }
+
+    TimerContent(
+        bookTitle = state.bookTitle,
+        author = state.author,
+        bookImageUrl = state.bookImageUrl,
+        isRunning = state.isRunning,
+        countdown = state.countdown,
+        displayTimeMMSS = state.displayTimeMMSS,
+        startPage = state.startPage,
+        totalPage = state.totalPage,
+        showMemoDialog = state.showMemoDialog,
+        showStopDialog = state.showStopDialog,
+        showBackExitScreen = state.showBackExitScreen,
+        memoLines = memoLines,
+        onToggle = viewModel::toggleRun,
+        onRequestStopDialog = { viewModel.requestStopDialog(wasRunning = state.isRunning) },
+        onDismissStopDialog = viewModel::dismissStopDialog,
+        onConfirmStopAndExit = { s, e ->
+            viewModel.finishAndSave(userBookId, s, e)
+            viewModel.dismissStopDialog(resumeTimer = false)
+            onExit()
+        },
+        onDismissBackExitScreen = viewModel::dismissBackExitScreen,
+        onStopAndExit = {
+            viewModel.stop()
+            viewModel.dismissBackExitScreen(resumeTimer = false)
+            onExit()
+        },
+        onShowMemoDialog = viewModel::showMemoDialog,
+        onDismissMemoDialog = viewModel::dismissMemoDialog,
+        onSaveMemo = { page, content ->
+            memoViewModel.add(
+                userBookId = userBookId,
+                pageNumber = page?.toIntOrNull(),
+                content = content,
+                title = state.bookTitle,
+                author = state.author,
+                imageUrl = state.bookImageUrl,
+            ) { viewModel.dismissMemoDialog() }
+        },
+        onOpenFloatingMode = {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val ctx = context
+                if (!Settings.canDrawOverlays(ctx)) {
+                    val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, "package:${ctx.packageName}".toUri())
+                    ctx.startActivity(intent)
+                    return@TimerContent
+                }
+            }
+            viewModel.startFloatingWindowMode(context)
+            (context as? Activity)?.moveTaskToBack(true)
+        },
+    )
+}
+
+@Composable
+private fun TimerContent(
+    bookTitle: String,
+    author: String,
+    bookImageUrl: String,
+    isRunning: Boolean,
+    countdown: Int?,
+    displayTimeMMSS: String,
+    startPage: Int?,
+    totalPage: Int?,
+    showMemoDialog: Boolean,
+    showStopDialog: Boolean,
+    showBackExitScreen: Boolean,
+    memoLines: List<String>,
+    onToggle: () -> Unit,
+    onRequestStopDialog: () -> Unit,
+    onDismissStopDialog: (resumeTimer: Boolean) -> Unit,
+    onConfirmStopAndExit: (startPage: Int, endPage: Int) -> Unit,
+    onDismissBackExitScreen: (resumeTimer: Boolean) -> Unit,
+    onStopAndExit: () -> Unit,
+    onShowMemoDialog: () -> Unit,
+    onDismissMemoDialog: () -> Unit,
+    onSaveMemo: (page: String?, content: String) -> Unit,
+    onOpenFloatingMode: () -> Unit,
+) {
+    val colors = GureumTheme.colors
+
+    var overlayRectWin by remember { mutableStateOf<Rect?>(null) }
+    var cardRectWin by remember { mutableStateOf<Rect?>(null) }
+    val cardRectForOverlay by remember(overlayRectWin, cardRectWin) {
+        mutableStateOf(
+            if (overlayRectWin != null && cardRectWin != null) {
+                val o = overlayRectWin!!
+                val c = cardRectWin!!
+                Rect(offset = Offset(c.left - o.left, c.top - o.top), size = c.size)
+            } else null,
+        )
     }
 
     Box(
@@ -125,49 +206,25 @@ fun TimerScreen(
             .onGloballyPositioned { overlayRectWin = it.boundsInWindow() },
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp),
+            modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(Modifier.height(24.dp))
 
-            // 현재 읽는 책 카드
             NowReadingCard(
-                title = state.bookTitle,
-                author = state.author,
-                imageUrl = state.bookImageUrl,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .onGloballyPositioned { coords ->
-                        cardRectWin = coords.boundsInWindow()
-                    },
+                title = bookTitle,
+                author = author,
+                imageUrl = bookImageUrl,
+                modifier = Modifier.fillMaxWidth().onGloballyPositioned { cardRectWin = it.boundsInWindow() },
             )
 
             Spacer(Modifier.height(24.dp))
 
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-            ) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 IconButton(
                     onClick = {
-                        if (state.countdown != null) return@IconButton
-
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                            if (!Settings.canDrawOverlays(context)) {
-                                val intent = Intent(
-                                    Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                                    "package:${context.packageName}".toUri(),
-                                )
-                                context.startActivity(intent)
-                                return@IconButton
-                            }
-                        }
-
-                        viewModel.startFloatingWindowMode(context)
-                        (context as? Activity)?.moveTaskToBack(true)
+                        if (countdown != null) return@IconButton
+                        onOpenFloatingMode()
                     },
                     modifier = Modifier.size(36.dp),
                 ) {
@@ -182,116 +239,110 @@ fun TimerScreen(
 
             Spacer(Modifier.height(8.dp))
 
-            // 원형 타이머
             TimerRing(
-                modifier = Modifier
-                    .size(240.dp)
-                    .offset(y = 12.dp),
-                isRunning = state.isRunning,
-                centerText = state.countdown?.toString() ?: state.displayTimeMMSS,
+                modifier = Modifier.size(240.dp).offset(y = 12.dp),
+                isRunning = isRunning,
+                centerText = countdown?.toString() ?: displayTimeMMSS,
             )
 
             Spacer(Modifier.height(40.dp))
 
-            // 메모 영역
-            val lines = remember(memoState.items, userBookId) {
-                memoState.items
-                    .filter { q -> q.userBookId == userBookId }
-                    .mapIndexed { idx, q -> "#${idx + 1} - ${q.content}" }
-            }
-
-            MemoList(
-                lines = lines,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-            )
+            MemoList(lines = memoLines, modifier = Modifier.fillMaxWidth().weight(1f))
 
             Spacer(Modifier.height(16.dp))
 
-            // 컨트롤(시작/일시정지, 정지, 메모편집)
             TimerControlsRow(
-                isRunning = state.isRunning,
+                isRunning = isRunning,
                 onToggle = {
-                    if (state.countdown != null) return@TimerControlsRow
-                    viewModel.toggleRun()
+                    if (countdown != null) return@TimerControlsRow
+                    onToggle()
                 },
                 onStop = {
-                    if (state.countdown != null) return@TimerControlsRow
-                    viewModel.requestStopDialog(wasRunning = state.isRunning)
+                    if (countdown != null) return@TimerControlsRow
+                    onRequestStopDialog()
                 },
                 onEdit = {
-                    if (state.countdown != null) return@TimerControlsRow
-                    viewModel.showMemoDialog()
+                    if (countdown != null) return@TimerControlsRow
+                    onShowMemoDialog()
                 },
             )
 
             Spacer(Modifier.height(32.dp))
         }
 
-        if (state.countdown != null) {
+        if (countdown != null) {
             CountdownOverlayWithHole(
-                number = state.countdown!!,
+                number = countdown,
                 holeRect = cardRectForOverlay,
                 holeCornerRadiusDp = 16f,
                 modifier = Modifier.fillMaxSize(),
             )
         }
 
-        // 정지 확인 다이얼로그
-        if (state.showStopDialog) {
+        if (showStopDialog) {
             StopReadingDialog(
-                displayTime = state.displayTimeMMSS,
-                title = state.bookTitle,
-                author = state.author,
-                currentPage = state.startPage,
-                totalPage = state.totalPage,
-                onConfirmStop = { viewModel.dismissStopDialog(resumeTimer = false) },
-                onDismiss = { viewModel.dismissStopDialog(resumeTimer = true) },
-                onConfirmStopPages = { s, e ->
-                    viewModel.finishAndSave(userBookId, s, e)
-                    viewModel.dismissStopDialog(resumeTimer = false)
-                    onExit()
-                },
+                displayTime = displayTimeMMSS,
+                title = bookTitle,
+                author = author,
+                currentPage = startPage,
+                totalPage = totalPage,
+                onConfirmStop = { onDismissStopDialog(false) },
+                onDismiss = { onDismissStopDialog(true) },
+                onConfirmStopPages = { s, e -> onConfirmStopAndExit(s, e) },
             )
         }
 
-        if (state.showMemoDialog) {
+        if (showMemoDialog) {
             AddQuoteDialog(
-                onDismiss = {
-                    viewModel.dismissMemoDialog()
-                },
+                onDismiss = onDismissMemoDialog,
                 onSave = { page, content ->
-                    memoViewModel.add(
-                        userBookId = userBookId,
-                        pageNumber = page?.toIntOrNull(),
-                        content = content,
-                        title = state.bookTitle,
-                        author = state.author,
-                        imageUrl = state.bookImageUrl,
-                    ) {
-                        // 저장 성공 후 다이얼로그 닫기
-                        viewModel.dismissMemoDialog()
-                    }
+                    onSaveMemo(page, content)
                 },
-                lastPage = state.totalPage,
+                lastPage = totalPage,
             )
         }
 
-        // 뒤로가기 다이얼로그
-        if (state.showBackExitScreen) {
+        if (showBackExitScreen) {
             StopReadingConfirmDialog(
-                displayTime = state.displayTimeMMSS,
-                title = state.bookTitle,
-                author = state.author,
+                displayTime = displayTimeMMSS,
+                title = bookTitle,
+                author = author,
                 willSave = false,
-                onContinue = { viewModel.dismissBackExitScreen(resumeTimer = true) },
-                onStop = {
-                    viewModel.stop()
-                    viewModel.dismissBackExitScreen(resumeTimer = false)
-                    onExit()
-                },
+                onContinue = { onDismissBackExitScreen(true) },
+                onStop = onStopAndExit,
             )
         }
+    }
+}
+
+@Preview(name = "Light", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun TimerPreview() {
+    GureumPageTheme {
+        TimerContent(
+            bookTitle = "채식주의자",
+            author = "한강",
+            bookImageUrl = "",
+            isRunning = true,
+            countdown = null,
+            displayTimeMMSS = "12:34",
+            startPage = 50,
+            totalPage = 300,
+            showMemoDialog = false,
+            showStopDialog = false,
+            showBackExitScreen = false,
+            memoLines = listOf("#1 - 인상깊은 문장"),
+            onToggle = {},
+            onRequestStopDialog = {},
+            onDismissStopDialog = {},
+            onConfirmStopAndExit = { _, _ -> },
+            onDismissBackExitScreen = {},
+            onStopAndExit = {},
+            onShowMemoDialog = {},
+            onDismissMemoDialog = {},
+            onSaveMemo = { _, _ -> },
+            onOpenFloatingMode = {},
+        )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerUiState.kt
@@ -12,7 +12,11 @@ data class TimerUiState(
     val startPage: Int? = null,
     val totalPage: Int? = null,
     val countdown: Int? = null,
-    val showMemoDialog: Boolean = false
+    val showMemoDialog: Boolean = false,
+    val showStopDialog: Boolean = false,
+    val wasRunningBeforeDialog: Boolean = false,
+    val showBackExitScreen: Boolean = false,
+    val wasRunningBeforeBack: Boolean = false,
 ) {
     val progress: Float
         get() {

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerUiState.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerUiState.kt
@@ -12,12 +12,12 @@ data class TimerUiState(
     val startPage: Int? = null,
     val totalPage: Int? = null,
     val countdown: Int? = null,
-    val showMemoDialog: Boolean = false,
-    val showStopDialog: Boolean = false,
-    val wasRunningBeforeDialog: Boolean = false,
-    val showBackExitScreen: Boolean = false,
-    val wasRunningBeforeBack: Boolean = false,
+    val dialogState: TimerDialogState = TimerDialogState.None,
 ) {
+    val showMemoDialog: Boolean get() = dialogState is TimerDialogState.Memo
+    val showStopDialog: Boolean get() = dialogState is TimerDialogState.StopConfirm
+    val showBackExitScreen: Boolean get() = dialogState is TimerDialogState.BackExit
+
     val progress: Float
         get() {
             val period = ringPeriodSec.coerceAtLeast(1)
@@ -33,3 +33,4 @@ data class TimerUiState(
             else "%02d:%02d".format(m, s)
         }
 }
+

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerViewModel.kt
@@ -12,11 +12,13 @@ import com.hihihihi.domain.usecase.history.AddHistoryUseCase
 import com.hihihihi.domain.usecase.userbook.GetUserBookByIdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -33,6 +35,9 @@ class TimerViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(TimerUiState())
     val uiState: StateFlow<TimerUiState> = _uiState
+
+    private val _effect = Channel<TimerEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
 
     val sharedTimerState = timerRepository.timerState
 
@@ -70,7 +75,7 @@ class TimerViewModel @Inject constructor(
             }
 
             is FloatingAction.OpenMemoDialog -> {
-                _uiState.update { it.copy(showMemoDialog = true) }
+                _uiState.update { it.copy(dialogState = TimerDialogState.Memo) }
             }
 
             is FloatingAction.ReturnToApp -> {
@@ -95,32 +100,28 @@ class TimerViewModel @Inject constructor(
         context.stopService(intent)
     }
 
-    fun showMemoDialog() {
-        _uiState.update { it.copy(showMemoDialog = true) }
+    fun showDialog(type: TimerDialogType) {
+        val wasRunning = _uiState.value.isRunning
+        if (type != TimerDialogType.Memo && wasRunning) pauseStopwatch()
+        _uiState.update {
+            it.copy(
+                dialogState = when (type) {
+                    TimerDialogType.Memo -> TimerDialogState.Memo
+                    TimerDialogType.StopConfirm -> TimerDialogState.StopConfirm(wasRunning)
+                    TimerDialogType.BackExit -> TimerDialogState.BackExit(wasRunning)
+                },
+            )
+        }
     }
 
-    fun dismissMemoDialog() {
-        _uiState.update { it.copy(showMemoDialog = false) }
-    }
-
-    fun requestStopDialog(wasRunning: Boolean) {
-        if (wasRunning) pauseStopwatch()
-        _uiState.update { it.copy(showStopDialog = true, wasRunningBeforeDialog = wasRunning) }
-    }
-
-    fun dismissStopDialog(resumeTimer: Boolean) {
-        _uiState.update { it.copy(showStopDialog = false) }
-        if (resumeTimer && _uiState.value.wasRunningBeforeDialog) start()
-    }
-
-    fun requestBackExitScreen(wasRunning: Boolean) {
-        if (wasRunning) pauseStopwatch()
-        _uiState.update { it.copy(showBackExitScreen = true, wasRunningBeforeBack = wasRunning) }
-    }
-
-    fun dismissBackExitScreen(resumeTimer: Boolean) {
-        _uiState.update { it.copy(showBackExitScreen = false) }
-        if (resumeTimer && _uiState.value.wasRunningBeforeBack) start()
+    fun dismissDialog(resumeTimer: Boolean = false) {
+        val wasRunning = when (val s = _uiState.value.dialogState) {
+            is TimerDialogState.StopConfirm -> s.wasRunning
+            is TimerDialogState.BackExit -> s.wasRunning
+            else -> false
+        }
+        _uiState.update { it.copy(dialogState = TimerDialogState.None) }
+        if (resumeTimer && wasRunning) start()
     }
 
     fun bind(userBookId: String) {
@@ -216,6 +217,16 @@ class TimerViewModel @Inject constructor(
 
         _uiState.update { it.copy(isRunning = false, elapsedSec = 0) }
         timerRepository.updateTimerState { it.copy(isRunning = false, elapsedSec = 0) }
+    }
+
+    fun openFloatingMode(canDrawOverlays: Boolean) {
+        viewModelScope.launch {
+            if (!canDrawOverlays) {
+                _effect.send(TimerEffect.RequestOverlayPermission)
+            } else {
+                _effect.send(TimerEffect.StartFloatingWindow)
+            }
+        }
     }
 
     fun startFloatingWindowMode(context: Context) {

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerViewModel.kt
@@ -89,7 +89,7 @@ class TimerViewModel @Inject constructor(
         val intent = Intent().apply {
             component = android.content.ComponentName(
                 "com.hihihihi.gureumpage",
-                "com.hihihihi.gureumpage.service.FloatingTimerService"
+                "com.hihihihi.gureumpage.service.FloatingTimerService",
             )
         }
         context.stopService(intent)
@@ -103,6 +103,26 @@ class TimerViewModel @Inject constructor(
         _uiState.update { it.copy(showMemoDialog = false) }
     }
 
+    fun requestStopDialog(wasRunning: Boolean) {
+        if (wasRunning) pauseStopwatch()
+        _uiState.update { it.copy(showStopDialog = true, wasRunningBeforeDialog = wasRunning) }
+    }
+
+    fun dismissStopDialog(resumeTimer: Boolean) {
+        _uiState.update { it.copy(showStopDialog = false) }
+        if (resumeTimer && _uiState.value.wasRunningBeforeDialog) start()
+    }
+
+    fun requestBackExitScreen(wasRunning: Boolean) {
+        if (wasRunning) pauseStopwatch()
+        _uiState.update { it.copy(showBackExitScreen = true, wasRunningBeforeBack = wasRunning) }
+    }
+
+    fun dismissBackExitScreen(resumeTimer: Boolean) {
+        _uiState.update { it.copy(showBackExitScreen = false) }
+        if (resumeTimer && _uiState.value.wasRunningBeforeBack) start()
+    }
+
     fun bind(userBookId: String) {
         booksJob = viewModelScope.launch {
             val userBook = getUserBook(userBookId).first()
@@ -113,7 +133,7 @@ class TimerViewModel @Inject constructor(
                     author = userBook.author,
                     bookImageUrl = userBook.imageUrl,
                     startPage = userBook.currentPage,
-                    totalPage = userBook.totalPage
+                    totalPage = userBook.totalPage,
                 )
             }
 
@@ -122,11 +142,11 @@ class TimerViewModel @Inject constructor(
                     bookInfo = BookInfo(
                         title = userBook.title,
                         author = userBook.author,
-                        imageUrl = userBook.imageUrl
+                        imageUrl = userBook.imageUrl,
                     ),
                     userBookId = userBook.userBookId,
                     startPage = userBook.currentPage,
-                    totalPage = userBook.totalPage
+                    totalPage = userBook.totalPage,
                 )
             }
         }
@@ -202,8 +222,8 @@ class TimerViewModel @Inject constructor(
         val intent = Intent().setComponent(
             android.content.ComponentName(
                 context.packageName,
-                "com.hihihihi.gureumpage.service.FloatingTimerService"
-            )
+                "com.hihihihi.gureumpage.service.FloatingTimerService",
+            ),
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             context.startForegroundService(intent)
@@ -216,8 +236,8 @@ class TimerViewModel @Inject constructor(
         val intent = Intent().setComponent(
             android.content.ComponentName(
                 context.packageName,
-                "com.hihihihi.gureumpage.service.FloatingTimerService"
-            )
+                "com.hihihihi.gureumpage.service.FloatingTimerService",
+            ),
         )
         context.stopService(intent)
     }
@@ -237,7 +257,7 @@ class TimerViewModel @Inject constructor(
             endTime = now,
             readTime = seconds,
             readPageCount = delta,
-            recordType = RecordType.TIMER
+            recordType = RecordType.TIMER,
         )
 
         viewModelScope.launch {
@@ -264,8 +284,8 @@ class TimerViewModel @Inject constructor(
                 bookInfo = BookInfo(
                     title = currentState.bookTitle,
                     author = currentState.author,
-                    imageUrl = currentState.bookImageUrl
-                )
+                    imageUrl = currentState.bookImageUrl,
+                ),
             )
         }
     }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/timer/TimerViewModel.kt
@@ -93,7 +93,7 @@ class TimerViewModel @Inject constructor(
     fun ensureFloatingWindowClosed(context: Context) {
         val intent = Intent().apply {
             component = android.content.ComponentName(
-                "com.hihihihi.gureumpage",
+                context.packageName,
                 "com.hihihihi.gureumpage.service.FloatingTimerService",
             )
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawScreen.kt
@@ -80,22 +80,7 @@ fun WithdrawScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val listState = rememberLazyListState()
     val lifecycleOwner = LocalLifecycleOwner.current
-
-    var currentHighlightedIndex by remember { mutableStateOf(0) }
-
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(3000)
-            currentHighlightedIndex = (currentHighlightedIndex + 1) % withdrawalReasons.size
-
-            listState.animateScrollToItem(
-                index = currentHighlightedIndex,
-                scrollOffset = -50
-            )
-        }
-    }
 
     LaunchedEffect(uiState.errorMessage) {
         uiState.errorMessage?.let { message ->
@@ -114,62 +99,60 @@ fun WithdrawScreen(
         }
     }
 
+    WithdrawContent(
+        userName = userName,
+        isLoading = uiState.isLoading,
+        loadingMessage = uiState.loadingMessage,
+        snackbarHostState = snackbarHostState,
+        onNavigateBack = onNavigateBack,
+        onWithdraw = viewModel::withdrawUser,
+    )
+}
+
+@Composable
+private fun WithdrawContent(
+    userName: String,
+    isLoading: Boolean,
+    loadingMessage: String,
+    snackbarHostState: SnackbarHostState,
+    onNavigateBack: () -> Unit,
+    onWithdraw: () -> Unit,
+) {
+    val listState = rememberLazyListState()
+    var currentHighlightedIndex by remember { mutableStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(3000)
+            currentHighlightedIndex = (currentHighlightedIndex + 1) % withdrawalReasons.size
+            listState.animateScrollToItem(index = currentHighlightedIndex, scrollOffset = -50)
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(24.dp)
             .navigationBarsPadding(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // 제목
-        Semi18Text(
-            text = "정말 떠나시나요?",
-            color = GureumTheme.colors.gray900,
-        )
-
+        Semi18Text(text = "정말 떠나시나요?", color = GureumTheme.colors.gray900)
         Spacer(modifier = Modifier.height(8.dp))
-
-        // 부제목
-        Medi14Text(
-            text = "${userName}님과 함께한",
-            color = GureumTheme.colors.gray400,
-        )
-
-        Medi14Text(
-            text = "소중한 독서 여정이 모두 사라져요",
-            color = GureumTheme.colors.gray400,
-        )
-
+        Medi14Text(text = "${userName}님과 함께한", color = GureumTheme.colors.gray400)
+        Medi14Text(text = "소중한 독서 여정이 모두 사라져요", color = GureumTheme.colors.gray400)
         Spacer(modifier = Modifier.height(24.dp))
 
-        // 경고 박스
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(
-                    GureumTheme.colors.systemRed.copy(alpha = 0.1f),
-                    RoundedCornerShape(12.dp)
-                )
-                .border(
-                    1.dp,
-                    GureumTheme.colors.systemRed.copy(alpha = 0.5f),
-                    RoundedCornerShape(12.dp)
-                )
-                .padding(16.dp)
+                .background(GureumTheme.colors.systemRed.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+                .border(1.dp, GureumTheme.colors.systemRed.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
+                .padding(16.dp),
         ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Semi16Text(
-                    text = "계정 탈퇴 시 삭제되는 데이터",
-                    color = GureumTheme.colors.systemRed
-                )
+            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                Semi16Text(text = "계정 탈퇴 시 삭제되는 데이터", color = GureumTheme.colors.systemRed)
                 Spacer(modifier = Modifier.height(4.dp))
-                Semi12Text(
-                    text = "한 번 삭제된 데이터는 복구될 수 없어요",
-                    color = GureumTheme.colors.gray700,
-                )
+                Semi12Text(text = "한 번 삭제된 데이터는 복구될 수 없어요", color = GureumTheme.colors.gray700)
             }
         }
 
@@ -179,13 +162,10 @@ fun WithdrawScreen(
             state = listState,
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(4.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             itemsIndexed(withdrawalReasons) { index, reason ->
-                WithdrawalReasonItem(
-                    reason = reason,
-                    isHighlighted = index == currentHighlightedIndex
-                )
+                WithdrawalReasonItem(reason = reason, isHighlighted = index == currentHighlightedIndex)
             }
         }
 
@@ -194,139 +174,71 @@ fun WithdrawScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(
-                    GureumTheme.colors.point.copy(alpha = 0.2f),
-                    RoundedCornerShape(12.dp)
-                )
-                .border(
-                    1.dp,
-                    GureumTheme.colors.point.copy(alpha = 0.5f),
-                    RoundedCornerShape(12.dp)
-                )
-                .padding(20.dp)
+                .background(GureumTheme.colors.point.copy(alpha = 0.2f), RoundedCornerShape(12.dp))
+                .border(1.dp, GureumTheme.colors.point.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
+                .padding(20.dp),
         ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Semi16Text(
-                    text = "잠깐만요! 🥺",
-                    color = GureumTheme.colors.gray900,
-                )
+            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                Semi16Text(text = "잠깐만요! 🥺", color = GureumTheme.colors.gray900)
                 Spacer(modifier = Modifier.height(8.dp))
-                Medi14Text(
-                    text = "지금까지 쌓아온 독서 기록들이 정말 아까워요.",
-                    color = GureumTheme.colors.gray500,
-                )
-                Medi14Text(
-                    text = "다시 한 번 생각해보시는 건 어떨까요?",
-                    color = GureumTheme.colors.gray500,
-                )
+                Medi14Text(text = "지금까지 쌓아온 독서 기록들이 정말 아까워요.", color = GureumTheme.colors.gray500)
+                Medi14Text(text = "다시 한 번 생각해보시는 건 어떨까요?", color = GureumTheme.colors.gray500)
             }
         }
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        // 버튼들
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            // 다시 생각해볼게요 버튼
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             Button(
-                onClick = { onNavigateBack() },
-                enabled = !uiState.isLoading,
-                modifier = Modifier
-                    .weight(1f)
-                    .height(48.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = GureumTheme.colors.primary
-                ),
-                shape = RoundedCornerShape(12.dp)
+                onClick = onNavigateBack,
+                enabled = !isLoading,
+                modifier = Modifier.weight(1f).height(48.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = GureumTheme.colors.primary),
+                shape = RoundedCornerShape(12.dp),
             ) {
-                Medi14Text(
-                    text = "다시 생각해볼게요",
-                    color = GureumTheme.colors.white,
-                )
+                Medi14Text(text = "다시 생각해볼게요", color = GureumTheme.colors.white)
             }
-
-            // 정말 탈퇴할래요 버튼
             Button(
-                onClick = { viewModel.withdrawUser() },
-                enabled = !uiState.isLoading,
-                modifier = Modifier
-                    .weight(1f)
-                    .height(48.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = GureumTheme.colors.gray200
-                ),
-                shape = RoundedCornerShape(12.dp)
+                onClick = onWithdraw,
+                enabled = !isLoading,
+                modifier = Modifier.weight(1f).height(48.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = GureumTheme.colors.gray200),
+                shape = RoundedCornerShape(12.dp),
             ) {
-                Medi14Text(
-                    text = "정말 탈퇴할래요",
-                    color = GureumTheme.colors.white,
-                )
+                Medi14Text(text = "정말 탈퇴할래요", color = GureumTheme.colors.white)
             }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
-
-        // 하단 안내 텍스트
-        Medi12Text(
-            text = "탈퇴 후에도 언제든 다시 돌아와서",
-            color = GureumTheme.colors.gray500,
-        )
+        Medi12Text(text = "탈퇴 후에도 언제든 다시 돌아와서", color = GureumTheme.colors.gray500)
         Spacer(modifier = Modifier.height(2.dp))
-        Medi12Text(
-            text = "새로운 독서 여정을 시작할 수 있어요",
-            color = GureumTheme.colors.gray500,
-        )
+        Medi12Text(text = "새로운 독서 여정을 시작할 수 있어요", color = GureumTheme.colors.gray500)
     }
 
-    if (uiState.isLoading) {
+    if (isLoading) {
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.Black.copy(alpha = 0.5f)),
-            contentAlignment = Alignment.Center
+            modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)),
+            contentAlignment = Alignment.Center,
         ) {
             Box(
                 modifier = Modifier
-                    .background(
-                        GureumTheme.background.color,
-                        RoundedCornerShape(12.dp)
-                    )
+                    .background(GureumTheme.background.color, RoundedCornerShape(12.dp))
                     .padding(32.dp),
-                contentAlignment = Alignment.Center
+                contentAlignment = Alignment.Center,
             ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(40.dp),
-                        color = GureumTheme.colors.primary
-                    )
-
-                    if (uiState.loadingMessage?.isNotEmpty() == true) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    CircularProgressIndicator(modifier = Modifier.size(40.dp), color = GureumTheme.colors.primary)
+                    if (loadingMessage.isNotEmpty()) {
                         Spacer(modifier = Modifier.height(16.dp))
-                        Medi14Text(
-                            text = uiState.loadingMessage!!,
-                            color = GureumTheme.colors.gray700
-                        )
+                        Medi14Text(text = loadingMessage, color = GureumTheme.colors.gray700)
                     }
                 }
             }
         }
     }
 
-    SnackbarHost(
-        hostState = snackbarHostState,
-    ) { data ->
-        Snackbar(
-            snackbarData = data,
-            containerColor = GureumTheme.colors.systemRed,
-            contentColor = Color.White
-        )
+    SnackbarHost(hostState = snackbarHostState) { data ->
+        Snackbar(snackbarData = data, containerColor = GureumTheme.colors.systemRed, contentColor = Color.White)
     }
 }
 
@@ -405,14 +317,18 @@ fun WithdrawalReasonItem(
     }
 }
 
-@Preview(showBackground = true)
+@Preview(name = "Light", showBackground = true)
+@Preview(name = "Dark")
 @Composable
-private fun WithdrawalScreenPreview() {
+private fun WithdrawPreview() {
     GureumPageTheme {
-        WithdrawScreen(
-            userName = "name",
-            onNavigateToLogin = {},
+        WithdrawContent(
+            userName = "구름이",
+            isLoading = false,
+            loadingMessage = "",
+            snackbarHostState = SnackbarHostState(),
             onNavigateBack = {},
+            onWithdraw = {},
         )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,8 +43,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.Medi12Text
 import com.hihihihi.presentation.designsystem.components.Medi14Text
@@ -55,7 +56,6 @@ import com.hihihihi.presentation.designsystem.components.Semi16Text
 import com.hihihihi.presentation.designsystem.components.Semi18Text
 import com.hihihihi.presentation.designsystem.theme.GureumPageTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTheme
-import com.hihihihi.presentation.navigation.NavigationRoute
 import kotlinx.coroutines.delay
 
 data class WithdrawalReason(
@@ -74,12 +74,14 @@ private val withdrawalReasons = listOf(
 @Composable
 fun WithdrawScreen(
     userName: String,
-    navController: NavHostController,
+    onNavigateToLogin: () -> Unit,
+    onNavigateBack: () -> Unit,
     viewModel: WithdrawViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val listState = rememberLazyListState()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     var currentHighlightedIndex by remember { mutableStateOf(0) }
 
@@ -102,10 +104,12 @@ fun WithdrawScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.withdrawEvent.collect {
-            navController.navigate(NavigationRoute.Login.route) {
-                popUpTo(0) { inclusive = true }
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.effect.collect { effect ->
+                when (effect) {
+                    WithdrawEffect.NavigateToLogin -> onNavigateToLogin()
+                }
             }
         }
     }
@@ -230,7 +234,7 @@ fun WithdrawScreen(
         ) {
             // 다시 생각해볼게요 버튼
             Button(
-                onClick = { navController.popBackStack() },
+                onClick = { onNavigateBack() },
                 enabled = !uiState.isLoading,
                 modifier = Modifier
                     .weight(1f)
@@ -406,8 +410,9 @@ fun WithdrawalReasonItem(
 private fun WithdrawalScreenPreview() {
     GureumPageTheme {
         WithdrawScreen(
-            "name",
-            navController = rememberNavController(),
+            userName = "name",
+            onNavigateToLogin = {},
+            onNavigateBack = {},
         )
     }
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -77,7 +77,7 @@ fun WithdrawScreen(
     navController: NavHostController,
     viewModel: WithdrawViewModel = hiltViewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val listState = rememberLazyListState()
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawScreen.kt
@@ -129,116 +129,121 @@ private fun WithdrawContent(
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp)
-            .navigationBarsPadding(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Semi18Text(text = "정말 떠나시나요?", color = GureumTheme.colors.gray900)
-        Spacer(modifier = Modifier.height(8.dp))
-        Medi14Text(text = "${userName}님과 함께한", color = GureumTheme.colors.gray400)
-        Medi14Text(text = "소중한 독서 여정이 모두 사라져요", color = GureumTheme.colors.gray400)
-        Spacer(modifier = Modifier.height(24.dp))
-
-        Box(
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .background(GureumTheme.colors.systemRed.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
-                .border(1.dp, GureumTheme.colors.systemRed.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
-                .padding(16.dp),
+                .fillMaxSize()
+                .padding(24.dp)
+                .navigationBarsPadding(),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-                Semi16Text(text = "계정 탈퇴 시 삭제되는 데이터", color = GureumTheme.colors.systemRed)
-                Spacer(modifier = Modifier.height(4.dp))
-                Semi12Text(text = "한 번 삭제된 데이터는 복구될 수 없어요", color = GureumTheme.colors.gray700)
-            }
-        }
+            Semi18Text(text = "정말 떠나시나요?", color = GureumTheme.colors.gray900)
+            Spacer(modifier = Modifier.height(8.dp))
+            Medi14Text(text = "${userName}님과 함께한", color = GureumTheme.colors.gray400)
+            Medi14Text(text = "소중한 독서 여정이 모두 사라져요", color = GureumTheme.colors.gray400)
+            Spacer(modifier = Modifier.height(24.dp))
 
-        Spacer(modifier = Modifier.height(24.dp))
-
-        LazyColumn(
-            state = listState,
-            modifier = Modifier.weight(1f),
-            contentPadding = PaddingValues(4.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            itemsIndexed(withdrawalReasons) { index, reason ->
-                WithdrawalReasonItem(reason = reason, isHighlighted = index == currentHighlightedIndex)
-            }
-        }
-
-        Spacer(modifier = Modifier.height(32.dp))
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(GureumTheme.colors.point.copy(alpha = 0.2f), RoundedCornerShape(12.dp))
-                .border(1.dp, GureumTheme.colors.point.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
-                .padding(20.dp),
-        ) {
-            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-                Semi16Text(text = "잠깐만요! 🥺", color = GureumTheme.colors.gray900)
-                Spacer(modifier = Modifier.height(8.dp))
-                Medi14Text(text = "지금까지 쌓아온 독서 기록들이 정말 아까워요.", color = GureumTheme.colors.gray500)
-                Medi14Text(text = "다시 한 번 생각해보시는 건 어떨까요?", color = GureumTheme.colors.gray500)
-            }
-        }
-
-        Spacer(modifier = Modifier.height(32.dp))
-
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            Button(
-                onClick = onNavigateBack,
-                enabled = !isLoading,
-                modifier = Modifier.weight(1f).height(48.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = GureumTheme.colors.primary),
-                shape = RoundedCornerShape(12.dp),
-            ) {
-                Medi14Text(text = "다시 생각해볼게요", color = GureumTheme.colors.white)
-            }
-            Button(
-                onClick = onWithdraw,
-                enabled = !isLoading,
-                modifier = Modifier.weight(1f).height(48.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = GureumTheme.colors.gray200),
-                shape = RoundedCornerShape(12.dp),
-            ) {
-                Medi14Text(text = "정말 탈퇴할래요", color = GureumTheme.colors.white)
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-        Medi12Text(text = "탈퇴 후에도 언제든 다시 돌아와서", color = GureumTheme.colors.gray500)
-        Spacer(modifier = Modifier.height(2.dp))
-        Medi12Text(text = "새로운 독서 여정을 시작할 수 있어요", color = GureumTheme.colors.gray500)
-    }
-
-    if (isLoading) {
-        Box(
-            modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)),
-            contentAlignment = Alignment.Center,
-        ) {
             Box(
                 modifier = Modifier
-                    .background(GureumTheme.background.color, RoundedCornerShape(12.dp))
-                    .padding(32.dp),
+                    .fillMaxWidth()
+                    .background(GureumTheme.colors.systemRed.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+                    .border(1.dp, GureumTheme.colors.systemRed.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
+                    .padding(16.dp),
+            ) {
+                Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Semi16Text(text = "계정 탈퇴 시 삭제되는 데이터", color = GureumTheme.colors.systemRed)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Semi12Text(text = "한 번 삭제된 데이터는 복구될 수 없어요", color = GureumTheme.colors.gray700)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.weight(1f),
+                contentPadding = PaddingValues(4.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                itemsIndexed(withdrawalReasons) { index, reason ->
+                    WithdrawalReasonItem(reason = reason, isHighlighted = index == currentHighlightedIndex)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(GureumTheme.colors.point.copy(alpha = 0.2f), RoundedCornerShape(12.dp))
+                    .border(1.dp, GureumTheme.colors.point.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
+                    .padding(20.dp),
+            ) {
+                Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Semi16Text(text = "잠깐만요! 🥺", color = GureumTheme.colors.gray900)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Medi14Text(text = "지금까지 쌓아온 독서 기록들이 정말 아까워요.", color = GureumTheme.colors.gray500)
+                    Medi14Text(text = "다시 한 번 생각해보시는 건 어떨까요?", color = GureumTheme.colors.gray500)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(
+                    onClick = onNavigateBack,
+                    enabled = !isLoading,
+                    modifier = Modifier.weight(1f).height(48.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = GureumTheme.colors.primary),
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Medi14Text(text = "다시 생각해볼게요", color = GureumTheme.colors.white)
+                }
+                Button(
+                    onClick = onWithdraw,
+                    enabled = !isLoading,
+                    modifier = Modifier.weight(1f).height(48.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = GureumTheme.colors.gray200),
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Medi14Text(text = "정말 탈퇴할래요", color = GureumTheme.colors.white)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Medi12Text(text = "탈퇴 후에도 언제든 다시 돌아와서", color = GureumTheme.colors.gray500)
+            Spacer(modifier = Modifier.height(2.dp))
+            Medi12Text(text = "새로운 독서 여정을 시작할 수 있어요", color = GureumTheme.colors.gray500)
+        }
+
+        if (isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)),
                 contentAlignment = Alignment.Center,
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator(modifier = Modifier.size(40.dp), color = GureumTheme.colors.primary)
-                    if (loadingMessage.isNotEmpty()) {
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Medi14Text(text = loadingMessage, color = GureumTheme.colors.gray700)
+                Box(
+                    modifier = Modifier
+                        .background(GureumTheme.background.color, RoundedCornerShape(12.dp))
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        CircularProgressIndicator(modifier = Modifier.size(40.dp), color = GureumTheme.colors.primary)
+                        if (loadingMessage.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Medi14Text(text = loadingMessage, color = GureumTheme.colors.gray700)
+                        }
                     }
                 }
             }
         }
-    }
 
-    SnackbarHost(hostState = snackbarHostState) { data ->
-        Snackbar(snackbarData = data, containerColor = GureumTheme.colors.systemRed, contentColor = Color.White)
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        ) { data ->
+            Snackbar(snackbarData = data, containerColor = GureumTheme.colors.systemRed, contentColor = Color.White)
+        }
     }
 }
 

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/withdraw/WithdrawViewModel.kt
@@ -7,12 +7,12 @@ import com.hihihihi.domain.usecase.auth.WithdrawUserUseCase
 import com.hihihihi.domain.usecase.user.ClearUserDataUseCase
 import com.hihihihi.domain.usecase.user.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -27,12 +27,10 @@ class WithdrawViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(WithdrawUiState())
     val uiState: StateFlow<WithdrawUiState> = _uiState.asStateFlow()
 
-    //탈퇴 이벤트
-    private val _withdrawEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val withdrawEvent: SharedFlow<Unit> = _withdrawEvent.asSharedFlow()
+    private val _effect = Channel<WithdrawEffect>(Channel.BUFFERED)
+    val effect: Flow<WithdrawEffect> = _effect.receiveAsFlow()
 
     private fun setLoading(isLoading: Boolean, message: String = "") {
-
         _uiState.value = _uiState.value.copy(
             isLoading = isLoading,
             loadingMessage = message,
@@ -74,19 +72,20 @@ class WithdrawViewModel @Inject constructor(
 
             clearUserDataUseCase.clearAll()
 
-            // 3. 상태 초기화 및 로그아웃 이벤트 발생
             setLoading(false)
-            _withdrawEvent.tryEmit(Unit)
+            _effect.send(WithdrawEffect.NavigateToLogin)
         } catch (e: Exception) {
-
             val errorMessage = when {
                 e.message?.contains("unauthenticated") == true -> "인증이 필요합니다"
                 e.message?.contains("not-found") == true -> "사용자를 찾을 수 없습니다"
                 e.message?.contains("permission-denied") == true -> "권한이 없습니다"
                 else -> "탈퇴 처리 중 오류가 발생했습니다: ${e.message}"
             }
-
             setError(errorMessage)
         }
     }
+}
+
+sealed interface WithdrawEffect {
+    data object NavigateToLogin : WithdrawEffect
 }


### PR DESCRIPTION
### ♟️ Issue
- close #173
- close #176 
- close #179 
- close #180 

## **✨ 주요 변경 사항**
1. Type-Safe Navigation 아키텍처 도입
- 컴포즈 네비게이션 마이그레이션: 기존의 String 기반 라우팅을 kotlinx-serialization을 활용한 Type-Safe Navigation 체계로 전면 교체하여 파라미터 전달의 안정성을 높였습니다.
- NavController 의존성 제거: 개별 컴포저블 내에 있던 NavHostController 직접 참조를 제거하고 상위 Graph 혹은 명시적인 콜백/이벤트 구조로 책임을 집중화했습니다.
- Effect(Side-Effect) 패턴 적용: 화면 이동 로직이나 권한 요청, 다이얼로그 이벤트 등을 처리하기 위해 TimerEffect, BookDetailEffect와 같은 단발성 이벤트를 Channel 기반으로 도입했습니다.
2. 레이어간 결합도 완화 및 UI 전용 Model 분리
- UI Model 도입: HomeUiModel, UserBookUiModel 등 Presentation 계층 전용 Model을 신설하여, UI 상태가 Domain 모델을 직접 참조하지 않도록 의존성을 분리했습니다.
- UI 상태 관리 중앙화: 각 컴포ઝ 화면 내부(remember, mutableStateOf)에 흩어져 있던 로컬 상태(다이얼로그 노출, 플래그 등)를 ViewModel과 UiState 계층으로 모두 이관했습니다 (ex: TimerDialogState sealed class 도입).
- 상태 갱신 정합성 확보: 비동기 업데이트 중의 동시성 문제를 방지하기 위해 MutableStateFlow에 .update { ... } 패턴을 일관되게 적용했습니다 (검색 페이지네이션, 각종 ViewModel 등).
3. Jetpack Compose 렌더링 성능 최적화
- Lifecycle-aware State Collection: 컴포저블의 생명주기를 고려하도록 전역의 collectAsState()를 collectAsStateWithLifecycle()로 전면 교체했습니다.
- Stateless 컴포저블 분리: 주요 Screen 컴포저블의 UI 구조를 Screen(상태 관리)과 Content(순수 UI 렌더링)로 분리하고, 다크모드/라이트모드 @Preview를 추가하여 디자인 점검 환경을 구성했습니다.
- Recomposition 방어: 주요 UI 모델에 @Immutable 어노테이션을 부여하고 rememberUpdatedState, derivedStateOf 등을 활용해 불필요한 재구성을 억제했습니다.
4. 기타 빌드 시스템 및 로직 개선
- 소셜 로그인 도중 발생하는 CancellationException의 예외 처리 로직을 수정하여 코루틴 중단 오류를 수정했습니다.
- libs.versions.toml을 통한 하드코딩 의존성 버전 관리 고도화 및 Bundle 구조 개선, 사용하지 않는 라이브러리 제거 작업 등을 진행했습니다.

## **✅ 체크리스트**
- [x]  🌱 merge 브랜치 확인
- [ ]  🙋 reviewer 설정
- [x]  👨‍🔧 assignees 설정
- [ ]  🏷️ label 설정
- [ ]  ⚙️ projects 등록
- [ ]  🛠️ development 이슈 등록

## **💬 비고**
- 이 PR은 #183 (Phase 2.1) 브랜치를 기반으로 합니다. 해당 PR 리뷰 시 Files Changed에는 2.2 단계에서 수정된 항목만 표시됩니다. 머지는 반드시 #183 PR 승인 및 병합 후에 순차적으로 진행되어야 합니다.
- 화면 렌더링 최적화 로직과 네비게이션 구조의 전면 변경이 두드러지게 반영되었습니다. StateFlow와 Type-Safe 전환으로 인한 화면 진입 엣지 케이스들을 중점적으로 확인 평가해 주시면 좋습니다.

## **📸 스크린샷**
- UI 변경사항 없음
