### PR TITLE
[Fix] develop: phase_2.3 소셜 로그인(Credential Manager) 변경사항 롤백

### DIFF
--- a/domain/src/main/java/com/hihihihi/domain/usecase/auth/SignInWithSocialTokenUseCase.kt
+++ b/domain/src/main/java/com/hihihihi/domain/usecase/auth/SignInWithSocialTokenUseCase.kt
@@ -10,7 +10,6 @@ class SignInWithSocialTokenUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
     suspend operator fun invoke(provider: SocialProvider, token: String): Result<Unit> = runSuspendCatching {
-        require(token.isNotBlank()) { "소셜 로그인 토큰이 비어 있습니다" }
         when (provider) {
             SocialProvider.KAKAO -> authRepository.kakaoLogin(token)
             SocialProvider.NAVER -> authRepository.naverLogin(token)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,8 +37,7 @@ javaxInject = "1"
 # Social Auth
 kakaoSdk = "2.23.2"
 naverOauth = "5.11.2"
-credentials = "1.6.0"
-googleid = "1.2.0"
+playServicesAuth = "21.4.0"
 
 # Image Loading
 coil = "3.4.0"
@@ -110,9 +109,7 @@ androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", vers
 # Social Auth
 kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoSdk" }
 naver-oauth = { group = "com.navercorp.nid", name = "oauth", version.ref = "naverOauth" }
-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
-googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
 
 # Image Loading (Coil)
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
@@ -177,9 +174,7 @@ firebase = [
 social-auth = [
     "kakao-user",
     "naver-oauth",
-    "credentials",
-    "credentials-play-services-auth",
-    "googleid"
+    "play-services-auth"
 ]
 coil = [
     "coil-compose",

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.Properties
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -9,11 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-val localProperties = Properties().apply {
-    val localFile = rootProject.file("local.properties")
-    if (localFile.exists()) load(localFile.inputStream())
-}
-
 android {
     namespace = "com.hihihihi.presentation"
     compileSdk = 36
@@ -21,12 +14,6 @@ android {
     defaultConfig {
         minSdk = 26
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-
-        val googleWebClientId = localProperties["GOOGLE_WEB_CLIENT_ID"]?.toString().orEmpty()
-        if (googleWebClientId.isBlank()) {
-            logger.warn("GOOGLE_WEB_CLIENT_ID가 비어 있습니다. local.properties를 확인해주세요.")
-        }
-        buildConfigField("String", "GOOGLE_WEB_CLIENT_ID", "\"$googleWebClientId\"")
     }
 
     buildTypes {
@@ -88,10 +75,6 @@ dependencies {
     implementation(libs.bundles.social.auth)
     implementation(libs.bundles.compose.extra)
     implementation(libs.kotlinx.serialization.json)
-
-    // Google Identity (googleid) SDK가 gson을 transitive 의존성으로 요구함
-    // kotlinx.serialization과 중복 사용 안 함 — 신규 JSON 코드는 kotlinx.serialization 사용할 것
-    implementation(libs.gson)
 
     ksp(libs.hilt.android.compiler)
     ksp(libs.androidx.hilt.compiler)


### PR DESCRIPTION
## 📌 배경

`develop` 브랜치에는 `refactor/phase_2.3` 전체가 머지된 상태입니다.
그러나 **소셜 로그인(Credential Manager) 관련 credential 설정 문제**로 인해 로그인 변경사항만 선택적으로 롤백합니다.

---

## ✅ 롤백 항목 (1번: 소셜 로그인)

| 파일 | 변경 내용 |
|------|----------|
| `gradle/libs.versions.toml` | `credentials`, `googleid` 의존성 제거 → `playServicesAuth` 복구 |
| `presentation/build.gradle.kts` | `GOOGLE_WEB_CLIENT_ID` buildConfigField 제거 |
| `domain/SignInWithSocialTokenUseCase.kt` | `require(token.isNotBlank())` 검증 제거 |

---

## 🔒 유지된 항목

**2번 (빌드 시스템 / ProGuard)**
- Java 17, compileSdk 36
- `isMinifyEnabled = true`, `isShrinkResources = true`
- ProGuard 룰셋 개편 (`app/proguard-rules.pro`, `data/consumer-rules.pro`)
- Version Catalog alias 일원화, AGP 9 / Gradle 9.4.1 / 라이브러리 전반 업그레이드

**3번 (Compose 성능 최적화)**
- `@Immutable` 어노테이션 UiState 적용 (`HomeUiState`, `BookDetailUiState` 등)
- `collectAsState` → `collectAsStateWithLifecycle` (`FloatingTimerService`)
- Splash 네비게이션 LaunchedEffect 중복 실행 버그 픽스
- `hiltViewModel` 신규 패키지 import 변경 (모든 화면)

---

## ✅ 체크리스트
- [x] 🌱 merge 브랜치 확인 (→ develop)
- [x] 소셜 로그인 관련 코드 제거 확인
- [x] 빌드 시스템 / Compose 최적화 유지 확인