### PR TITLE
[Fix] 소셜 로그인(Credential Manager) 변경사항 롤백

### DIFF
--- a/domain/src/main/java/com/hihihihi/domain/usecase/auth/SignInWithSocialTokenUseCase.kt
+++ b/domain/src/main/java/com/hihihihi/domain/usecase/auth/SignInWithSocialTokenUseCase.kt
@@ -10,7 +10,6 @@ class SignInWithSocialTokenUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
     suspend operator fun invoke(provider: SocialProvider, token: String): Result<Unit> = runSuspendCatching {
-        require(token.isNotBlank()) { "소셜 로그인 토큰이 비어 있습니다" }
         when (provider) {
             SocialProvider.KAKAO -> authRepository.kakaoLogin(token)
             SocialProvider.NAVER -> authRepository.naverLogin(token)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,8 +37,7 @@ javaxInject = "1"
 # Social Auth
 kakaoSdk = "2.23.2"
 naverOauth = "5.11.2"
-credentials = "1.6.0"
-googleid = "1.2.0"
+playServicesAuth = "21.4.0"
 
 # Image Loading
 coil = "3.4.0"
@@ -110,9 +109,7 @@ androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", vers
 # Social Auth
 kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoSdk" }
 naver-oauth = { group = "com.navercorp.nid", name = "oauth", version.ref = "naverOauth" }
-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
-googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
 
 # Image Loading (Coil)
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
@@ -177,9 +174,7 @@ firebase = [
 social-auth = [
     "kakao-user",
     "naver-oauth",
-    "credentials",
-    "credentials-play-services-auth",
-    "googleid"
+    "play-services-auth"
 ]
 coil = [
     "coil-compose",

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.Properties
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -9,11 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-val localProperties = Properties().apply {
-    val localFile = rootProject.file("local.properties")
-    if (localFile.exists()) load(localFile.inputStream())
-}
-
 android {
     namespace = "com.hihihihi.presentation"
     compileSdk = 36
@@ -21,12 +14,6 @@ android {
     defaultConfig {
         minSdk = 26
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-
-        val googleWebClientId = localProperties["GOOGLE_WEB_CLIENT_ID"]?.toString().orEmpty()
-        if (googleWebClientId.isBlank()) {
-            logger.warn("GOOGLE_WEB_CLIENT_ID가 비어 있습니다. local.properties를 확인해주세요.")
-        }
-        buildConfigField("String", "GOOGLE_WEB_CLIENT_ID", "\"$googleWebClientId\"")
     }
 
     buildTypes {
@@ -89,8 +76,7 @@ dependencies {
     implementation(libs.bundles.compose.extra)
     implementation(libs.kotlinx.serialization.json)
 
-    // Google Identity (googleid) SDK가 gson을 transitive 의존성으로 요구함
-    // kotlinx.serialization과 중복 사용 안 함 — 신규 JSON 코드는 kotlinx.serialization 사용할 것
+    // Widget에서 Gson 직접 사용 (HistoryHeatMapWidget, CurrentReadingBookWidget 등)
     implementation(libs.gson)
 
     ksp(libs.hilt.android.compiler)

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginScreen.kt
@@ -2,7 +2,6 @@ package com.hihihihi.presentation.ui.login
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -36,15 +35,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.credentials.exceptions.GetCredentialCancellationException
-import androidx.credentials.exceptions.NoCredentialException
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.hihihihi.domain.usecase.auth.SocialProvider
-import com.hihihihi.presentation.BuildConfig
 import com.hihihihi.presentation.R
 import com.hihihihi.presentation.designsystem.components.Medi12Text
 import com.hihihihi.presentation.designsystem.components.Medi14Text
@@ -54,8 +50,6 @@ import com.hihihihi.presentation.designsystem.theme.GureumTheme
 import com.hihihihi.presentation.designsystem.theme.GureumTypography
 import com.hihihihi.presentation.ui.login.components.SocialLoginButton
 import com.hihihihi.presentation.ui.login.util.SocialLoginManager
-import com.navercorp.nid.NidOAuth
-import com.navercorp.nid.core.data.errorcode.NidOAuthErrorCode
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
@@ -73,15 +67,10 @@ fun LoginScreen(
     val coroutineScope = rememberCoroutineScope()
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    val naverLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.StartActivityForResult(),
-    ) { _ ->
-        val token = NidOAuth.getAccessToken()
-        if (token != null) {
-            viewModel.loginWithSocialToken(SocialProvider.NAVER, token)
-        } else if (NidOAuth.getLastErrorCode() != NidOAuthErrorCode.CLIENT_USER_CANCEL) {
-            viewModel.setError("네이버 로그인에 실패했습니다.")
-        }
+    val googleLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        result.data?.let { intent -> viewModel.handleGoogleSignInResult(intent) }
     }
 
     LaunchedEffect(lifecycleOwner) {
@@ -107,32 +96,27 @@ fun LoginScreen(
         isLoading = uiState.isLoading,
         loadingMessage = uiState.loadingMessage,
         snackbarHostState = snackbarHostState,
-        onGoogleLogin = {
-            val act = activity ?: return@LoginContent
-            coroutineScope.launch {
-                runCatching { SocialLoginManager.getGoogleIdToken(act, BuildConfig.GOOGLE_WEB_CLIENT_ID) }
-                    .onSuccess { viewModel.loginWithSocialToken(SocialProvider.GOOGLE, it) }
-                    .onFailure {
-                        if (it is GetCredentialCancellationException) return@onFailure
-                        if (it is NoCredentialException) return@onFailure
-                        viewModel.setError("구글 로그인에 실패했습니다. 다시 시도해주세요.")
-                    }
-            }
-        },
+        onGoogleLogin = { viewModel.googleLogin(context, googleLauncher) },
         onKakaoLogin = {
-            val act = activity ?: return@LoginContent
             coroutineScope.launch {
-                runCatching { SocialLoginManager.loginWithKakao(act) }
+                runCatching { SocialLoginManager.loginWithKakao(context) }
                     .onSuccess { viewModel.loginWithSocialToken(SocialProvider.KAKAO, it) }
                     .onFailure {
                         if (it is CancellationException) throw it
-                        Log.e("KakaoLogin", "SDK error: ${it::class.simpleName} - ${it.message}", it)
                         viewModel.setError("카카오 로그인에 실패했습니다.")
                     }
             }
         },
         onNaverLogin = {
-            NidOAuth.requestLogin(context, naverLauncher)
+            val act = activity ?: return@LoginContent
+            coroutineScope.launch {
+                runCatching { SocialLoginManager.loginWithNaver(act) }
+                    .onSuccess { viewModel.loginWithSocialToken(SocialProvider.NAVER, it) }
+                    .onFailure {
+                        if (it is CancellationException) throw it
+                        viewModel.setError("네이버 로그인에 실패했습니다.")
+                    }
+            }
         },
     )
 }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/login/LoginViewModel.kt
@@ -1,7 +1,12 @@
 package com.hihihihi.presentation.ui.login
 
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.hihihihi.domain.usecase.auth.GetCurrentUserIdUseCase
 import com.hihihihi.domain.usecase.auth.SignInWithSocialTokenUseCase
 import com.hihihihi.domain.usecase.auth.SocialProvider
@@ -11,7 +16,7 @@ import com.hihihihi.domain.usecase.user.GetUserUseCase
 import com.hihihihi.domain.usecase.user.SetLastProviderUseCase
 import com.hihihihi.domain.usecase.user.SetOnboardingCompleteUseCase
 import com.hihihihi.domain.usecase.user.WaitForUserDocumentCreationUseCase
-import android.util.Log
+import com.hihihihi.presentation.ui.login.util.SocialLoginManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -44,7 +49,7 @@ class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(
                 lastProvider = getLastProvider(),
-                errorMessage = null
+                errorMessage = null,
             )
         }
     }
@@ -90,19 +95,48 @@ class LoginViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(
             isLoading = isLoading,
             loadingMessage = message,
-            errorMessage = null
+            errorMessage = null,
         )
     }
 
     internal fun setError(message: String) {
         _uiState.value = _uiState.value.copy(
             isLoading = false,
-            errorMessage = message
+            errorMessage = message,
         )
     }
 
     fun clearError() {
         _uiState.value = _uiState.value.copy(errorMessage = null)
+    }
+
+    fun googleLogin(
+        context: Context,
+        launcher: ActivityResultLauncher<Intent>,
+    ) {
+        setLoading(true, "구글 로그인 중...")
+
+        val webClientIdResId = context.resources.getIdentifier("default_web_client_id", "string", context.packageName)
+        val defaultWebClientId = if (webClientIdResId != 0) context.getString(webClientIdResId) else ""
+
+        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(defaultWebClientId)
+            .requestEmail()
+            .build()
+
+        val client = GoogleSignIn.getClient(context, gso)
+        launcher.launch(client.signInIntent)
+    }
+
+    fun handleGoogleSignInResult(data: Intent) {
+        viewModelScope.launch {
+            try {
+                val idToken = SocialLoginManager.getGoogleIdToken(data)
+                loginWithSocialToken(SocialProvider.GOOGLE, idToken)
+            } catch (_: Exception) {
+                setError("구글 로그인에 실패했습니다. 다시 시도해주세요.")
+            }
+        }
     }
 
     fun loginWithSocialToken(provider: SocialProvider, accessToken: String) {
@@ -112,8 +146,7 @@ class LoginViewModel @Inject constructor(
                 signInWithSocialTokenUseCase(provider, accessToken)
                 setLastProviderUseCase(provider.name.lowercase())
                 navigateAfterLogin()
-            } catch (e: Exception) {
-                Log.e("LoginViewModel", "소셜 로그인 실패", e)
+            } catch (_: Exception) {
                 setError("로그인에 실패했습니다. 다시 시도해주세요.")
             }
         }

--- a/presentation/src/main/java/com/hihihihi/presentation/ui/login/util/SocialLoginManager.kt
+++ b/presentation/src/main/java/com/hihihihi/presentation/ui/login/util/SocialLoginManager.kt
@@ -1,43 +1,28 @@
 package com.hihihihi.presentation.ui.login.util
 
 import android.app.Activity
-import androidx.credentials.CredentialManager
-import androidx.credentials.CustomCredential
-import androidx.credentials.GetCredentialRequest
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
-import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import android.content.Context
+import android.content.Intent
+import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import com.navercorp.nid.NidOAuth
+import com.navercorp.nid.oauth.util.NidOAuthCallback
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 object SocialLoginManager {
 
-    suspend fun getGoogleIdToken(activity: Activity, webClientId: String): String {
-        val credentialManager = CredentialManager.create(activity)
-        val googleIdOption = GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false)
-            .setServerClientId(webClientId)
-            .build()
-        val request = GetCredentialRequest.Builder()
-            .addCredentialOption(googleIdOption)
-            .build()
-        val result = credentialManager.getCredential(activity, request)
-
-        // 타입 체크: CustomCredential 중 Google ID Token이 아닌 경우 명시적 예외
-        val credential = result.credential
-        if (credential is CustomCredential &&
-            credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
-        ) {
-            return GoogleIdTokenCredential.createFrom(credential.data).idToken
-        }
-        throw IllegalStateException("Unexpected credential type: ${credential.type}")
+    fun getGoogleIdToken(intent: Intent): String {
+        val task = GoogleSignIn.getSignedInAccountFromIntent(intent)
+        val account = task.result
+        return account.idToken ?: throw Exception("Google idToken is null")
     }
 
-    suspend fun loginWithKakao(activity: Activity): String =
+    suspend fun loginWithKakao(context: Context): String =
         suspendCancellableCoroutine { cont ->
             val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
                 when {
@@ -46,23 +31,44 @@ object SocialLoginManager {
                     else -> cont.resumeWithException(Exception("Unknown kakao failure"))
                 }
             }
-            if (UserApiClient.instance.isKakaoTalkLoginAvailable(activity)) {
-                UserApiClient.instance.loginWithKakaoTalk(activity) { token, error ->
+            if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+                UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
                     if (error != null) {
                         if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
                             cont.cancel(); return@loginWithKakaoTalk
                         }
-                        UserApiClient.instance.loginWithKakaoAccount(activity, callback = callback)
-                    } else if (token != null && cont.isActive) {
+                        UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+                    } else if (token != null) {
                         cont.resume(token.accessToken)
-                    } else {
-                        // token/error 모두 null → 웹 로그인으로 fallback
-                        UserApiClient.instance.loginWithKakaoAccount(activity, callback = callback)
                     }
                 }
             } else {
-                UserApiClient.instance.loginWithKakaoAccount(activity, callback = callback)
+                UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
             }
         }
 
+    suspend fun loginWithNaver(activity: Activity): String =
+        suspendCancellableCoroutine { cont ->
+            NidOAuth.requestLogin(
+                activity,
+                object : NidOAuthCallback {
+                    override fun onSuccess() {
+                        val token = NidOAuth.getAccessToken()
+                        if (token != null) {
+                            cont.resume(token)
+                        } else {
+                            cont.resumeWithException(Exception("Naver accessToken is null"))
+                        }
+                    }
+
+                    override fun onFailure(errorCode: String, errorDesc: String) {
+                        if (errorCode == "user_cancel") {
+                            cont.cancel()
+                        } else {
+                            cont.resumeWithException(Exception("Naver login failed: $errorCode, $errorDesc"))
+                        }
+                    }
+                },
+            )
+        }
 }


### PR DESCRIPTION
## 📌 배경

`develop` 브랜치에는 `refactor/phase_2.3` 전체가 머지된 상태입니다.
그러나 **소셜 로그인(Credential Manager) 관련 credential 설정 문제**로 인해 로그인 변경사항만 선택적으로 롤백합니다.

---

## ✅ 롤백 항목 (1번: 소셜 로그인)

| 파일 | 변경 내용 |
|------|----------|
| `gradle/libs.versions.toml` | `credentials`, `googleid` 의존성 제거 → `playServicesAuth` 복구 |
| `presentation/build.gradle.kts` | `GOOGLE_WEB_CLIENT_ID` buildConfigField 제거 |
| `domain/SignInWithSocialTokenUseCase.kt` | `require(token.isNotBlank())` 검증 제거 |

---

## 🔒 유지된 항목

**2번 (빌드 시스템 / ProGuard)**
- Java 17, compileSdk 36
- `isMinifyEnabled = true`, `isShrinkResources = true`
- ProGuard 룰셋 개편 (`app/proguard-rules.pro`, `data/consumer-rules.pro`)
- Version Catalog alias 일원화, AGP 9 / Gradle 9.4.1 / 라이브러리 전반 업그레이드

**3번 (Compose 성능 최적화)**
- `@Immutable` 어노테이션 UiState 적용 (`HomeUiState`, `BookDetailUiState` 등)
- `collectAsState` → `collectAsStateWithLifecycle` (`FloatingTimerService`)
- Splash 네비게이션 LaunchedEffect 중복 실행 버그 픽스
- `hiltViewModel` 신규 패키지 import 변경 (모든 화면)

---

## ✅ 체크리스트
- [x] 🌱 merge 브랜치 확인 (→ develop)
- [x] 소셜 로그인 관련 코드 제거 확인
- [x] 빌드 시스템 / Compose 최적화 유지 확인